### PR TITLE
Show voting period on festival page

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "concurrently": "^5.3.0",
     "cors": "^2.8.5",
     "culturestake-contracts": "^1.0.28",
+    "date-fns": "^2.17.0",
     "express": "^4.17.1",
     "express-basic-auth": "^1.2.0",
     "graphql": "^15.3.0",

--- a/src/common/helpers/strings.js
+++ b/src/common/helpers/strings.js
@@ -1,3 +1,7 @@
+export const isString = (x) => {
+  return typeof x === 'string';
+};
+
 export function uppercaseFirst(str) {
   return `${str[0].toUpperCase()}${str.substr(1)}`;
 }

--- a/src/common/utils/time.js
+++ b/src/common/utils/time.js
@@ -1,1 +1,12 @@
+import { isString } from '~/common/helpers/strings';
+
 export const dateToTimestamp = (date) => Math.floor(date.getTime() / 1000);
+
+/*
+ * Supply the epoch value in seconds.
+ */
+export const epochToDate = (value) => {
+  const epoch = isString(epoch) ? parseInt(value, 10) : value;
+
+  return new Date(epoch * 1000);
+};


### PR DESCRIPTION
closes #97

Merging this commit gives a quick way for administrators to see associated voting period for this festival. I chose a human readable approach over absolute dates. I always find that more pleasant. I use the [`date-fns`](https://date-fns.org/) library to create those human readable time strings. I assume Webpack does tree shaking, so the additional bundle size shouldn't be a lot. Otherwise we can opt to import just the required functions from individual modules.

![Screen Shot 2021-02-26 at 14 33 51](https://user-images.githubusercontent.com/29301569/109333970-01f1a180-7858-11eb-8e22-4bfa0fb43d62.png)

![Screen Shot 2021-02-26 at 14 33 42](https://user-images.githubusercontent.com/29301569/109333985-06b65580-7858-11eb-841d-79141ef9158c.png)

![Screen Shot 2021-02-26 at 14 33 32](https://user-images.githubusercontent.com/29301569/109333994-0a49dc80-7858-11eb-86ba-39f090e0f14c.png)
