### PR TITLE
Remove image credits requirement on Artworks

### DIFF
--- a/src/client/components/FormArtworks.js
+++ b/src/client/components/FormArtworks.js
@@ -26,7 +26,7 @@ const FormArtworks = () => {
     subtitle: Joi.string().max(255).required(),
     title: Joi.string().max(128).required(),
     url: Joi.string().uri().allow(''),
-    imageCredits: Joi.string().max(500),
+    imageCredits: Joi.string().max(500).allow(''),
   };
 
   return (

--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 
 import InputArtworksField from '~/client/components/InputArtworksField';
+import InputCheckboxField from '~/client/components/InputCheckboxField';
 import InputField from '~/client/components/InputField';
 import InputStickerField from '~/client/components/InputStickerField';
 import InputTextareaField from '~/client/components/InputTextareaField';
@@ -20,6 +21,7 @@ const FormFestivals = () => {
     description: Joi.string().max(2000).required(),
     documents: documentsValidation.max(3),
     images: imagesValidation.max(10),
+    online: Joi.boolean(),
     sticker: stickerValidation.required(),
     subtitle: Joi.string().max(255).required(),
     title: Joi.string().max(128).required(),
@@ -53,6 +55,12 @@ const FormFestivals = () => {
         label={translate('FormFestivals.fieldDescription')}
         name="description"
         validate={schema.description}
+      />
+
+      <InputCheckboxField
+        label={translate('FormFestivals.fieldOnline')}
+        name="online"
+        validate={schema.online}
       />
 
       <InputUploadField

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -38,6 +38,7 @@ const AdminFestivalsEditForm = () => {
       'description',
       'documents',
       'images',
+      'online',
       'sticker',
       'subtitle',
       'title',

--- a/src/client/views/AdminFestivalsNew.js
+++ b/src/client/views/AdminFestivalsNew.js
@@ -24,6 +24,7 @@ const AdminFestivalsNew = () => {
       'description',
       'documents',
       'images',
+      'online',
       'sticker',
       'subtitle',
       'title',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -70,6 +70,7 @@ const components = {
     fieldDescription: 'Description:',
     fieldDocuments: 'Documents',
     fieldImages: 'Images',
+    fieldOnline: 'Online',
     fieldSticker: 'Sticker',
     fieldSubtitle: 'Subtitle',
     fieldTitle: 'Title:',

--- a/src/server/controllers/festivals.js
+++ b/src/server/controllers/festivals.js
@@ -33,7 +33,7 @@ import { respondWithSuccess } from '~/server/helpers/respond';
 
 const options = {
   model: Festival,
-  fields: [...festivalFields, 'images', 'artworks', 'voteweights'],
+  fields: [...festivalFields, 'images', 'artworks', 'online', 'voteweights'],
   fieldsProtected: ['documents', 'chainId'],
   include: [
     FestivalBelongsToManyArtworks,

--- a/src/server/database/migrations/20210302152823-add-online-to-festivals.js
+++ b/src/server/database/migrations/20210302152823-add-online-to-festivals.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('festivals', 'online', {
+      type: Sequelize.BOOLEAN,
+    });
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('festivals', 'online');
+  },
+};

--- a/src/server/models/festival.js
+++ b/src/server/models/festival.js
@@ -39,6 +39,11 @@ const Festival = db.define('festival', {
     type: DataTypes.TEXT,
     allowNull: false,
   },
+  online: {
+    type: DataTypes.BOOLEAN,
+    allowNull: true,
+    default: false,
+  },
   sticker: {
     type: DataTypes.STRING,
   },

--- a/src/server/validations/festivals.js
+++ b/src/server/validations/festivals.js
@@ -14,6 +14,7 @@ const defaultValidation = {
   description: Joi.string().max(2000).required(),
   documents: documentsValidation.max(3),
   images: imagesValidation.max(10),
+  online: Joi.boolean(),
   sticker: stickerValidation.required(),
   subtitle: Joi.string().max(255).required(),
   title: Joi.string().max(128).required(),


### PR DESCRIPTION
This commit removes the requirement for image credits on the New Artwork form. It does not achieve the same effect for the Edit Artwork form.