### PR TITLE
Add Joi.allow('') to image credits field on artworks form

### DIFF
--- a/src/client/components/FormArtworks.js
+++ b/src/client/components/FormArtworks.js
@@ -21,12 +21,12 @@ const FormArtworks = () => {
     description: Joi.string().max(2000).required(),
     descriptionCommission: Joi.string().max(2000).required(),
     documents: documentsValidation.required().max(3),
+    imageCredits: Joi.string().max(500).allow(''),
     images: imagesValidation.required().max(10),
     sticker: stickerValidation.required(),
     subtitle: Joi.string().max(255).required(),
     title: Joi.string().max(128).required(),
     url: Joi.string().uri().allow(''),
-    imageCredits: Joi.string().max(500).allow(''),
   };
 
   return (

--- a/src/client/components/FormArtworks.js
+++ b/src/client/components/FormArtworks.js
@@ -26,7 +26,7 @@ const FormArtworks = () => {
     subtitle: Joi.string().max(255).required(),
     title: Joi.string().max(128).required(),
     url: Joi.string().uri().allow(''),
-    imageCredits: Joi.string().max(500),
+    imageCredits: Joi.string().max(500).allow(''),
   };
 
   return (

--- a/src/client/views/AdminArtworksEdit.js
+++ b/src/client/views/AdminArtworksEdit.js
@@ -27,6 +27,7 @@ const AdminArtworksEdit = () => {
       'description',
       'descriptionCommission',
       'documents',
+      'imageCredits',
       'images',
       'sticker',
       'subtitle',

--- a/src/client/views/AdminArtworksNew.js
+++ b/src/client/views/AdminArtworksNew.js
@@ -23,6 +23,7 @@ const AdminArtworksNew = () => {
       'description',
       'descriptionCommission',
       'documents',
+      'imageCredits',
       'images',
       'sticker',
       'subtitle',

--- a/src/client/views/Artworks.js
+++ b/src/client/views/Artworks.js
@@ -31,6 +31,7 @@ const Artworks = () => {
             return (
               <ArtworksItem
                 festivalSlug={params.festivalSlug}
+                imageCredits={artwork.imageCredits}
                 images={artwork.images}
                 key={artwork.id}
                 slug={artwork.slug}

--- a/src/server/models/artwork.js
+++ b/src/server/models/artwork.js
@@ -48,6 +48,7 @@ const Artwork = db.define('artwork', {
   },
   imageCredits: {
     type: DataTypes.STRING,
+    allowNull: true,
   },
 });
 

--- a/src/server/validations/artworks.js
+++ b/src/server/validations/artworks.js
@@ -15,13 +15,13 @@ const defaultValidation = {
   artistId: Joi.number().integer().positive(),
   description: Joi.string().max(2000).required(),
   descriptionCommission: Joi.string().max(2000).required(),
+  imageCredits: Joi.string().max(500).allow(''),
   images: imagesValidation.max(10),
   documents: documentsValidation.max(3),
   sticker: stickerValidation.required(),
   title: Joi.string().max(128).required(),
   subtitle: Joi.string().max(255).required(),
   url: Joi.string().uri().allow(''),
-  imageCredits: Joi.string().max(500),
 };
 
 export default {


### PR DESCRIPTION
Removes image credits requirement from New Artwork form. Does not have the same effect for Edit Artwork form.