### PR TITLE
Schedule email tasks and additionally provide recipients via CSV files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5682,6 +5682,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+    },
     "autoprefixer": {
       "version": "9.8.6",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -10501,6 +10506,21 @@
             "ajv": "^6.12.4",
             "ajv-keywords": "^3.5.2"
           }
+        }
+      }
+    },
+    "file-selector": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz",
+      "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -17524,6 +17544,16 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-dropzone": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.3.1.tgz",
+      "integrity": "sha512-gPyw524T6dYZW81aQoBGmBG90cVNs+YJreh3HaN45Yw09Bm6m4aA6IF9ergHZQAWGeDSJ+DUhDKKAAaDdTj3RQ==",
+      "requires": {
+        "attr-accept": "^2.2.1",
+        "file-selector": "^0.2.2",
+        "prop-types": "^15.7.2"
       }
     },
     "react-fit": {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "react": "^16.13.1",
     "react-datetime-picker": "^3.0.2",
     "react-dom": "^16.13.1",
+    "react-dropzone": "^11.3.1",
     "react-form": "^4.0.1",
     "react-promise-suspense": "^0.3.3",
     "react-redux": "^7.2.1",

--- a/src/client/components/FileUpload.js
+++ b/src/client/components/FileUpload.js
@@ -1,0 +1,90 @@
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
+import styled from 'styled-components';
+import DropZone from 'react-dropzone';
+import { useSelector } from 'react-redux';
+
+import styles from '~/client/styles/variables';
+import { isString } from '~/common/helpers/strings';
+
+const DEFAULT_UPLOAD_TEXT =
+  'Upload files by dragging &amp; dropping it here or click to select.';
+
+const FileUpload = ({
+  onUpload,
+  onError,
+  accept = [],
+  uploadText = DEFAULT_UPLOAD_TEXT,
+}) => {
+  const { isAlternateColor } = useSelector((state) => state.app);
+
+  const onDrop = useCallback(
+    (files) => {
+      const reader = new FileReader();
+
+      reader.addEventListener('abort', () =>
+        onError('file reading was aborted'),
+      );
+
+      reader.addEventListener('error', () =>
+        onError('file reading has failed'),
+      );
+
+      reader.addEventListener('load', () => {
+        if (isString(reader.result)) {
+          onUpload(reader.result);
+        }
+      });
+
+      files.forEach((file) => reader.readAsText(file));
+    },
+    [onUpload, onError],
+  );
+
+  return (
+    <DropZone accept={accept} multiple={false} onDrop={onDrop}>
+      {({ getRootProps, getInputProps, isDragActive }) => (
+        <div {...getRootProps()}>
+          <input {...getInputProps()} />
+
+          <FileUploadStyle isAlternateColor={isAlternateColor}>
+            {isDragActive ? <p>Drop your file here</p> : <p>{uploadText}</p>}
+          </FileUploadStyle>
+        </div>
+      )}
+    </DropZone>
+  );
+};
+
+FileUpload.propTypes = {
+  accept: PropTypes.arrayOf(PropTypes.string),
+  onError: PropTypes.func.isRequired,
+  onUpload: PropTypes.func.isRequired,
+  uploadText: PropTypes.string,
+};
+
+export const FileUploadStyle = styled.div`
+  max-width: 100%;
+
+  padding: 3rem;
+  padding-right: 1.5rem;
+  padding-left: 1.5rem;
+
+  border: 1.5px solid ${styles.colors.violet};
+  border-radius: 5px;
+
+  vertical-align: middle;
+
+  white-space: nowrap;
+
+  color: ${(props) =>
+    props.isAlternateColor ? styles.colors.yellow : styles.colors.white};
+
+  background-color: ${styles.colors.violet};
+
+  text-overflow: ellipsis;
+
+  text-align: center;
+`;
+
+export default FileUpload;

--- a/src/client/components/FormScheduleEmail.js
+++ b/src/client/components/FormScheduleEmail.js
@@ -1,0 +1,29 @@
+import Joi from 'joi';
+import React, { Fragment } from 'react';
+
+import InputTextareaField from '~/client/components/InputTextareaField';
+import translate from '~/common/services/i18n';
+
+export const schema = {
+  recipients: Joi.string()
+    .trim()
+    .lowercase()
+    // Top-Level domains are not available in the browser build of Joi.
+    .email({ multiple: true, separator: '\n', tlds: { allow: false } })
+    .required(),
+};
+
+const FormScheduleEmail = () => {
+  return (
+    <Fragment>
+      <InputTextareaField
+        label={translate('FormScheduleEmail.fieldRecipients')}
+        name="recipients"
+        rows={15}
+        validate={schema.recipients}
+      />
+    </Fragment>
+  );
+};
+
+export default FormScheduleEmail;

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -13,6 +13,7 @@ import AdminArtworks from '~/client/views/AdminArtworks';
 import AdminArtworksEdit from '~/client/views/AdminArtworksEdit';
 import AdminArtworksNew from '~/client/views/AdminArtworksNew';
 import AdminBooths from '~/client/views/AdminBooths';
+import AdminEmails from '~/client/views/AdminEmails';
 import AdminFestivals from '~/client/views/AdminFestivals';
 import AdminFestivalsEdit from '~/client/views/AdminFestivalsEdit';
 import AdminFestivalsNew from '~/client/views/AdminFestivalsNew';
@@ -196,6 +197,11 @@ const Routes = () => (
       component={AdminAnswersEdit}
       exact
       path="/admin/questions/:questionId/answers/:answerId/edit"
+    />
+    <AuthenticatedRoute
+      component={AdminEmails}
+      exact
+      path="/admin/emails"
     />
     <AuthenticatedRoute
       component={AdminProperties}

--- a/src/client/views/Admin.js
+++ b/src/client/views/Admin.js
@@ -51,6 +51,10 @@ const Admin = () => {
             <ButtonOutline to="/admin/questions">
               {translate('Admin.linkAdminQuestions')}
             </ButtonOutline>
+
+            <ButtonOutline to="/admin/emails">
+              {translate('Admin.linkAdminEmails')}
+            </ButtonOutline>
           </AdminNavigationStyle>
         </BoxRounded>
 

--- a/src/client/views/AdminEmails.js
+++ b/src/client/views/AdminEmails.js
@@ -1,0 +1,138 @@
+import React, { Fragment } from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import Joi from 'joi';
+
+import ButtonIcon from '~/client/components/ButtonIcon';
+import FileUpload from '~/client/components/FileUpload';
+import FooterAdmin from '~/client/components/FooterAdmin';
+import HeaderAdmin from '~/client/components/HeaderAdmin';
+import ViewAdmin from '~/client/components/ViewAdmin';
+import ButtonSubmit from '~/client/components/ButtonSubmit';
+import translate from '~/common/services/i18n';
+import { SpacingGroupStyle } from '~/client/styles/layout';
+import notify, {
+  NotificationsTypes,
+} from '~/client/store/notifications/actions';
+import { useRequestId } from '~/client/hooks/requests';
+import { putRequest } from '~/client/store/api/actions';
+import FormScheduleEmail, {
+  schema,
+} from '~/client/components/FormScheduleEmail';
+import { useRequestForm } from '~/client/hooks/forms';
+
+const AdminEmails = () => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const requestId = useRequestId();
+
+  const returnUrl = '/admin';
+
+  const textareaToRecipients = (value) =>
+    [
+      ...value.split('\n').reduce((memo, email) => memo.add(email), new Set()),
+    ].sort();
+
+  const recipientsToTextarea = (recipients, existing = []) =>
+    [
+      ...recipients
+        .concat(existing)
+        .reduce((memo, email) => memo.add(email), new Set()),
+    ]
+      .sort()
+      .join('\n');
+
+  const {
+    Form,
+    setValues,
+    values,
+    meta: { isValid },
+  } = useRequestForm({
+    requestId,
+    schema,
+    onSubmit: (values) => {
+      dispatch(
+        putRequest({
+          id: requestId,
+          path: ['tasks'],
+          body: {
+            kind: 'vote_invitations',
+            data: textareaToRecipients(values.recipients).map((to) => ({ to })),
+          },
+        }),
+      );
+    },
+    onError: () => {
+      dispatch(
+        notify({
+          text: translate('default.errorMessage'),
+          type: NotificationsTypes.ERROR,
+        }),
+      );
+    },
+    onSuccess: () => {
+      dispatch(
+        notify({
+          text: translate('AdminEmails.notificationSuccess', {
+            amount: textareaToRecipients(values.recipients).length,
+          }),
+        }),
+      );
+      history.push(returnUrl);
+    },
+  });
+
+  const handleFileUpload = (contents) => {
+    const emails = textareaToRecipients(contents).filter((line) => {
+      try {
+        Joi.assert(line, schema.recipients);
+      } catch (e) {
+        return false;
+      }
+      return true;
+    });
+    const recipients = textareaToRecipients(values.recipients);
+
+    setValues({
+      recipients: recipientsToTextarea(emails, recipients),
+    });
+  };
+
+  const handleFileUploadError = () => {
+    dispatch(
+      notify({
+        text: translate('default.errorMessage'),
+        type: NotificationsTypes.ERROR,
+      }),
+    );
+  };
+
+  return (
+    <Fragment>
+      <HeaderAdmin>{translate('AdminEmails.title')}</HeaderAdmin>
+
+      <ViewAdmin>
+        <Form>
+          <FormScheduleEmail />
+          <FileUpload
+            accept={['text/plain', 'text/csv', 'text/x-csv']}
+            uploadText={translate('AdminEmails.fileUpload')}
+            onError={handleFileUploadError}
+            onUpload={handleFileUpload}
+          />
+          <ButtonSubmit disabled={!isValid} />
+        </Form>
+      </ViewAdmin>
+
+      <FooterAdmin>
+        <SpacingGroupStyle>
+          <ButtonIcon isIconFlipped to="/admin">
+            {translate('default.buttonReturnToDashboard')}
+          </ButtonIcon>
+        </SpacingGroupStyle>
+      </FooterAdmin>
+    </Fragment>
+  );
+};
+
+export default AdminEmails;

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -77,6 +77,9 @@ const components = {
     fieldArtworks: 'Artworks:',
     fieldUrl: 'Website:',
   },
+  FormScheduleEmail: {
+    fieldRecipients: 'Recipients:',
+  },
   FormUsers: {
     fieldEmail: 'Email-address:',
     fieldPassword: 'Password:',
@@ -260,6 +263,7 @@ const views = {
     linkAdminProperties: 'Properties',
     linkAdminQuestions: 'Questions',
     linkAdminUsers: 'Users',
+    linkAdminEmails: 'Schedule Invitations',
   },
   AdminLogin: {
     buttonSubmit: 'Login',
@@ -308,6 +312,12 @@ const views = {
     buttonNewQuestion: 'Create new question',
     fieldTitle: 'Title',
     title: 'Questions',
+  },
+  AdminEmails: {
+    buttonSendEmails: 'Schedule Emails',
+    title: 'Schedule Email',
+    notificationSuccess: 'Scheduled {amount} emails.',
+    fileUpload: 'Drag a file with recipients here or click to select.',
   },
   AdminQuestionsNew: {
     title: 'Create new question',

--- a/src/common/utils/constants.js
+++ b/src/common/utils/constants.js
@@ -2,3 +2,4 @@ export const SENTINEL_ADDRESS = '0x0000000000000000000000000000000000000001';
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const MAX_VOTE_TOKENS = 10;
 export const isDev = process.env.NODE_ENV === 'development';
+export const isTest = process.env.NODE_ENV === 'test';

--- a/src/server/controllers/tasks.js
+++ b/src/server/controllers/tasks.js
@@ -1,0 +1,22 @@
+import httpStatus from 'http-status';
+
+import { respondWithSuccess } from '~/server/helpers/respond';
+import { voteInvitationEmail } from '~/server/tasks/sendmail';
+
+async function create(req, res) {
+  const { kind, data } = req.body;
+
+  switch (kind) {
+    case 'vote_invitations': {
+      await Promise.all(
+        data.map(({ to, ...rest }) => voteInvitationEmail(to, rest)),
+      );
+    }
+  }
+
+  respondWithSuccess(res, undefined, httpStatus.CREATED);
+}
+
+export default {
+  create,
+};

--- a/src/server/emails/vote-invitation.pug
+++ b/src/server/emails/vote-invitation.pug
@@ -1,0 +1,1 @@
+p You are invited to vote.

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -15,6 +15,7 @@ import uploadsRouter from '~/server/routes/uploads';
 import usersRouter from '~/server/routes/users';
 import votesRouter from '~/server/routes/votes';
 import voteweightsRouter from '~/server/routes/voteweights';
+import tasksRouter from '~/server/routes/tasks';
 import { respondWithSuccess } from '~/server/helpers/respond';
 
 const router = express.Router();
@@ -46,6 +47,8 @@ router.use('/answers', answersRouter);
 router.use('/organisations', organisationsRouter);
 
 router.use('/voteweights', voteweightsRouter);
+
+router.use('/tasks', tasksRouter);
 
 router.use(() => {
   throw new APIError(httpStatus.NOT_FOUND);

--- a/src/server/routes/tasks.js
+++ b/src/server/routes/tasks.js
@@ -1,0 +1,17 @@
+import express from 'express';
+
+import authMiddleware from '~/server/middlewares/passport';
+import tasksController from '~/server/controllers/tasks';
+import tasksValidation from '~/server/validations/tasks';
+import validate from '~/server/services/validate';
+
+const router = express.Router();
+
+router.put(
+  '/',
+  authMiddleware,
+  validate(tasksValidation.create),
+  tasksController.create,
+);
+
+export default router;

--- a/src/server/tasks/sendmail.js
+++ b/src/server/tasks/sendmail.js
@@ -1,7 +1,7 @@
 import Queue from 'bull';
 
 import processor from '~/server/tasks/processor';
-import { isDev } from '~/common/utils/constants';
+import { isDev, isTest } from '~/common/utils/constants';
 import { redisUrl, redisLongRunningOptions } from '~/server/services/redis';
 import mailer, {
   prodTransporter,
@@ -15,7 +15,7 @@ const mailing = new Queue('Send mails', redisUrl, {
 
 processor(mailing).process(
   async ({ data: { to, subject, template, data = {} } }) => {
-    const send = mailer(isDev ? devTransporter : prodTransporter);
+    const send = mailer(isDev || isTest ? devTransporter : prodTransporter);
     return send(to, subject, template, data);
   },
 );
@@ -24,6 +24,14 @@ export const testEmail = (to = 'me@example.org', data = { name: 'Meesix' }) =>
   submitJob(mailing, to, {
     subject: 'Testing the email sending',
     template: 'test',
+    to,
+    data,
+  });
+
+export const voteInvitationEmail = (to = 'me@example.org', data = {}) =>
+  submitJob(mailing, `${to}#voteInvitation`, {
+    subject: 'You are invited to vote',
+    template: 'vote-invitation',
     to,
     data,
   });

--- a/src/server/tasks/submitJob.js
+++ b/src/server/tasks/submitJob.js
@@ -1,5 +1,9 @@
 import logger from '~/server/helpers/logger';
+import { isTest } from '~/common/utils/constants';
 
+// The default job options don't work very well during unit tests. Jobs don't
+// complete in time. We will use these default job options only if we are not in
+// a test environment.
 const jobDefaultOptions = {
   timeout: 1000 * 60 * 40,
   attempts: 100,
@@ -18,7 +22,7 @@ export default function submitJob(queue, id, data = {}, jobOptions = {}) {
 
     return queue.add(
       { id, ...data },
-      { jobId: id, ...jobDefaultOptions, ...jobOptions },
+      { jobId: id, ...(isTest ? {} : jobDefaultOptions), ...jobOptions },
     );
   });
 }

--- a/src/server/validations/tasks.js
+++ b/src/server/validations/tasks.js
@@ -1,0 +1,31 @@
+import { Joi, Segments } from 'celebrate';
+
+const taskKind = Joi.string().valid('vote_invitations').required();
+
+const defaultValidation = {
+  kind: taskKind,
+  data: Joi.alternatives().conditional('kind', {
+    switch: [
+      {
+        is: 'vote_invitations',
+        then: Joi.array()
+          .items(
+            Joi.object({
+              to: Joi.string().email().required(),
+            }),
+          )
+          .min(1)
+          .required(),
+        otherwise: Joi.object().allow(null).default(null),
+      },
+    ],
+  }),
+};
+
+export default {
+  create: {
+    [Segments.BODY]: {
+      ...defaultValidation,
+    },
+  },
+};

--- a/test/data/tasks.json
+++ b/test/data/tasks.json
@@ -1,0 +1,6 @@
+{
+  "voteInvitation": {
+    "kind": "vote_invitations",
+    "data": [{ "to": "aaa@example.org" }, { "to": "bbb@example.org" }]
+  }
+}

--- a/test/helpers/tasks.js
+++ b/test/helpers/tasks.js
@@ -1,0 +1,13 @@
+export const expectNoTasks = async (queue) => {
+  const stats = await queue.getJobCounts();
+
+  return expect(Object.keys(stats).every((state) => stats[state] === 0)).toBe(
+    true,
+  );
+};
+
+export const expectCompletedTasks = async (queue, count) => {
+  const completed = await queue.getCompletedCount();
+
+  return expect(completed).toBe(count);
+};

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -1,0 +1,17 @@
+export const delay = (ms, value) => {
+  let cancel;
+
+  // eslint-disable-next-line promise/avoid-new
+  const thunk = new Promise((resolve, reject) => {
+    let timeOut = setTimeout(() => resolve(value), ms);
+    cancel = () => {
+      if (timeOut) {
+        clearTimeout(timeOut);
+        timeOut = null;
+      }
+      reject(new Error('Promise canceled'));
+    };
+  });
+  thunk.cancel = cancel;
+  return thunk;
+};

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -1,0 +1,55 @@
+import httpStatus from 'http-status';
+
+import createSupertest from './helpers/supertest';
+import tasksData from './data/tasks';
+import { initializeDatabase } from './helpers/database';
+import queue from '../src/server/tasks/sendmail';
+
+describe('Tasks', () => {
+  let authRequest;
+
+  beforeAll(async () => {
+    await initializeDatabase();
+    await queue.empty();
+    authRequest = await createSupertest();
+  });
+
+  afterAll(async () => {
+    await queue.empty();
+  });
+
+  describe('PUT /api/tasks', () => {
+    it('should fail with an unknown task type', async () => {
+      await authRequest
+        .put('/api/tasks')
+        .send({ kind: 'nonexistent' })
+        .expect(httpStatus.BAD_REQUEST);
+    });
+
+    describe('scheduling vote invitation email tasks', () => {
+      it('should succeed creating new email tasks', async () => {
+        await authRequest
+          .put('/api/tasks')
+          .send(tasksData.voteInvitation)
+          .expect(httpStatus.CREATED);
+      });
+
+      it('should fail with no recipients', async () => {
+        const { kind } = tasksData.voteInvitation;
+
+        await Promise.all([
+          // No recipients.
+          authRequest
+            .put('/api/tasks')
+            .send({ kind, data: [] })
+            .expect(httpStatus.BAD_REQUEST),
+          // Missing recipients.
+          authRequest
+            .put('/api/tasks')
+            .send({ kind, data: [{ xxx: 'missing to field' }] })
+            .expect(httpStatus.BAD_REQUEST),
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
refs #105 

This commit does a few things:

- Add a HTTP endpoint to push tasks to the Redis queue. This endpoint is
  generic and can be used for more and different tasks in the future.
- Provide an interface for admins to add recipients. There is a textarea
  input that can be used to manually enter one recipient per line.
- Upload CSV files containing recipients. One or more CSV files can be
  uploaded and recipients are added cumulative. This allows a mix and
  match approach between uploading CSV files and editing email addresses
  in the browser.

I created an imaginary task for vote invitations. I believe this is
similar to what #136 will require. This part might require refactoring
when we get to it though.

I added tests for the HTTP endpoints but have no idea how to test the
task queueing or the actual email sending.