### PR TITLE
Filter artworks by festival when creating a new question

### DIFF
--- a/src/client/components/FormQuestions.js
+++ b/src/client/components/FormQuestions.js
@@ -6,7 +6,8 @@ import InputField from '~/client/components/InputField';
 import InputFinderField from '~/client/components/InputFinderField';
 import translate from '~/common/services/i18n';
 
-const FormQuestions = ({ isFinderDisabled }) => {
+const FormQuestions = ({ isFinderDisabled, festivalId }) => {
+  const hasFestival = !!festivalId;
   const schema = {
     title: Joi.string().max(128).required(),
     festivalId: Joi.number()
@@ -17,6 +18,14 @@ const FormQuestions = ({ isFinderDisabled }) => {
       .integer()
       .allow(null)
       .error(new Error(translate('validations.artworkRequired'))),
+  };
+
+  const filter = (item) => {
+    const filtered = item.festivals.filter(
+      (festival) => festival.id === festivalId,
+    );
+
+    return filtered.length >= 1;
   };
 
   return (
@@ -39,7 +48,8 @@ const FormQuestions = ({ isFinderDisabled }) => {
       />
 
       <InputFinderField
-        isDisabled={isFinderDisabled}
+        clientSideFilter={filter}
+        isDisabled={isFinderDisabled || !hasFestival}
         label={translate('FormQuestions.fieldArtwork')}
         name="artworkId"
         placeholder={translate('FormQuestions.fieldArtworkPlaceholder')}
@@ -53,6 +63,7 @@ const FormQuestions = ({ isFinderDisabled }) => {
 };
 
 FormQuestions.propTypes = {
+  festivalId: PropTypes.number,
   isFinderDisabled: PropTypes.bool,
 };
 

--- a/src/client/hooks/forms.js
+++ b/src/client/hooks/forms.js
@@ -104,7 +104,7 @@ export const useNewForm = ({
   const history = useHistory();
   const requestId = useRequestId();
 
-  const { Form, setFieldValue } = useRequestForm({
+  const { Form, setFieldValue, setValues, values } = useRequestForm({
     requestId,
     onSubmit: (values) => {
       dispatch(
@@ -135,6 +135,8 @@ export const useNewForm = ({
   return {
     Form,
     setFieldValue,
+    setValues,
+    values,
   };
 };
 
@@ -166,6 +168,7 @@ export const useEditForm = ({
 
   const {
     Form,
+    values,
     meta: { canSubmit },
   } = useRequestForm({
     requestId,
@@ -239,6 +242,7 @@ export const useEditForm = ({
     Form,
     isResourceLoading,
     resource,
+    values,
   };
 };
 

--- a/src/client/views/AdminQuestionsEdit.js
+++ b/src/client/views/AdminQuestionsEdit.js
@@ -25,7 +25,13 @@ const AdminQuestionsEdit = () => {
   const dispatch = useDispatch();
   const [isInitialized, setIsInitialized] = useState(false);
 
-  const { ButtonDelete, Form, isResourceLoading, resource } = useEditForm({
+  const {
+    ButtonDelete,
+    Form,
+    isResourceLoading,
+    resource,
+    values: { festivalId },
+  } = useEditForm({
     fields: ['artworkId', 'festivalId', 'title'],
     resourcePath: ['questions', questionId],
     returnUrl,
@@ -70,7 +76,7 @@ const AdminQuestionsEdit = () => {
 
       <ViewAdmin>
         <Form>
-          <FormQuestions isFinderDisabled />
+          <FormQuestions festivalId={festivalId} isFinderDisabled />
 
           <BoxRounded title={translate(`AdminQuestionsEdit.bodyAnswers`)}>
             <AnswersTable

--- a/src/client/views/AdminQuestionsNew.js
+++ b/src/client/views/AdminQuestionsNew.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import ButtonIcon from '~/client/components/ButtonIcon';
@@ -16,8 +16,13 @@ import { useNewForm } from '~/client/hooks/forms';
 const AdminQuestionsNew = () => {
   const dispatch = useDispatch();
   const returnUrl = '/admin/questions';
+  const [festivalIdCache, setFestivalIdCache] = useState();
 
-  const { Form } = useNewForm({
+  const {
+    Form,
+    setValues,
+    values: { title, festivalId },
+  } = useNewForm({
     fields: ['title', 'festivalId', 'artworkId'],
     resourcePath: ['questions'],
     returnUrl,
@@ -40,13 +45,24 @@ const AdminQuestionsNew = () => {
     },
   });
 
+  // Artworks are chosen based on the festival. When selecting a new festival we
+  // want to invalidate the select artwork since a different festival has
+  // different artworks to choose from. To achieve this I cache the selected
+  // festivalId and forcefully invalidate the artworkId if it changes.
+  useEffect(() => {
+    if (festivalId != festivalIdCache) {
+      setFestivalIdCache(festivalId);
+      setValues({ title, festivalId, artworkId: null });
+    }
+  }, [setValues, title, festivalId, festivalIdCache]);
+
   return (
     <Fragment>
       <HeaderAdmin>{translate('AdminQuestionsNew.title')}</HeaderAdmin>
 
       <ViewAdmin>
         <Form>
-          <FormQuestions />
+          <FormQuestions festivalId={festivalId} />
           <ButtonSubmit />
         </Form>
       </ViewAdmin>


### PR DESCRIPTION
refs #127

This commit makes three major changes to the UI when creating new
questions.

- Artworks can only be selected once a festival has been selected.
- Artworks are filtered based on the selected festival.
- When selecting a different festival the selected artwork get's reset.

The filtering of artworks by festivals happens client-side. It certainly
would be nicer to do this on the database layer but Sequelize and I
couldn't agree on a way how to do that really.