### PR TITLE
Show an error notification when enabling the ethereum wallet fails

### DIFF
--- a/src/client/store/ethereum/actions.js
+++ b/src/client/store/ethereum/actions.js
@@ -5,10 +5,14 @@ import notify, {
 import translate from '~/common/services/i18n';
 import web3 from '~/common/services/web3';
 import { detectMetaMask, enableProvider } from '~/client/services/ethereum';
+import { isContract } from '~/common/services/contracts';
 import { isOwner } from '~/common/services/contracts/owners';
 
 async function handleAccountChange(accounts, dispatch) {
   try {
+    if (!(await isContract(process.env.ADMIN_CONTRACT)))
+      throw new Error('No smart contract found for this account.');
+
     const isOwnerState =
       accounts && accounts.length > 0 ? await isOwner(accounts[0]) : false;
 
@@ -28,7 +32,9 @@ async function handleAccountChange(accounts, dispatch) {
   } catch (e) {
     dispatch(
       notify({
-        text: translate('ethereum.notificationAccountFailure'),
+        text: `${translate('ethereum.notificationAccountFailure')}: ${
+          e.message
+        }`,
         type: NotificationsTypes.ERROR,
       }),
     );

--- a/src/client/store/ethereum/reducers.js
+++ b/src/client/store/ethereum/reducers.js
@@ -27,6 +27,11 @@ const ethereumReducer = (state = initialState, action) => {
         account: { $set: action.meta.account },
         isOwner: { $set: action.meta.isOwner },
       });
+    case ActionTypes.ETHEREUM_ACCOUNT_FAILURE:
+      return update(state, {
+        account: { $set: initialState.account },
+        isOwner: { $set: initialState.isOwner },
+      });
     case ActionTypes.ETHEREUM_TRANSACTIONS_ADD:
       return update(state, {
         transactions: {

--- a/src/client/store/ethereum/types.js
+++ b/src/client/store/ethereum/types.js
@@ -2,6 +2,7 @@ import createTypes from 'redux-create-action-types';
 
 export default createTypes(
   'ETHEREUM_ACCOUNT_CHANGED',
+  'ETHEREUM_ACCOUNT_FAILURE',
   'ETHEREUM_INITIALIZE',
   'ETHEREUM_TRANSACTIONS_ADD',
   'ETHEREUM_TRANSACTIONS_UPDATE',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -244,6 +244,8 @@ const store = {
   },
   ethereum: {
     notificationAccountEnabled: 'Activated Smart Contracts Snuggle Panel',
+    notificationAccountFailure:
+      'Failed to activate Smart Contracts Snuggle Panel',
   },
 };
 

--- a/src/common/services/contracts/index.js
+++ b/src/common/services/contracts/index.js
@@ -17,6 +17,14 @@ export function getQuestionContract(address) {
   return getContract(QuestionContract.abi, address);
 }
 
+export async function isContract(address) {
+  const code = await web3.eth.getCode(address);
+  // A valid contract is a string with `0x` as a prefix. If no other characters
+  // follow the prefix it is an invalid contract.
+  if (/^0x.+/.test(code)) return true;
+  return false;
+}
+
 // Admin contract methods
 
 export const adminContract = getAdminContract(process.env.ADMIN_CONTRACT);


### PR DESCRIPTION
refs #96

When enabling the ethereum wallet in the snuggle panel a success
notification is show, always, even if the action failed. This commit is
not yet really showing why the action failed, but at least shows a
proper error notification.