### PR TITLE
Add .falsy('') to client and server festivals online validations

### DIFF
--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -21,7 +21,7 @@ const FormFestivals = () => {
     description: Joi.string().max(2000).required(),
     documents: documentsValidation.max(3),
     images: imagesValidation.max(10),
-    online: Joi.boolean(),
+    online: Joi.boolean().falsy(''),
     sticker: stickerValidation.required(),
     subtitle: Joi.string().max(255).required(),
     title: Joi.string().max(128).required(),

--- a/src/server/validations/festivals.js
+++ b/src/server/validations/festivals.js
@@ -14,7 +14,7 @@ const defaultValidation = {
   description: Joi.string().max(2000).required(),
   documents: documentsValidation.max(3),
   images: imagesValidation.max(10),
-  online: Joi.boolean(),
+  online: Joi.boolean().falsy(''),
   sticker: stickerValidation.required(),
   subtitle: Joi.string().max(255).required(),
   title: Joi.string().max(128).required(),


### PR DESCRIPTION
Adds .falsy('') to both client and server festival-online checkbox validations, to allow for initial state of undefined (which is passed as an empty string from the forms.useField hook) to be boolean-validated as false.