### PR TITLE
Initialize answers inline of the question view.

### DIFF
--- a/src/client/components/AnswersTable.js
+++ b/src/client/components/AnswersTable.js
@@ -3,12 +3,19 @@ import React from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
-import Table, { ACTION_EDIT } from '~/client/components/Table';
+import Table, {
+  ACTION_ANSWER_INITIALIZE,
+  ACTION_EDIT,
+} from '~/client/components/Table';
 import translate from '~/common/services/i18n';
 
 const table = {
   path: ['answers'],
   actions: [
+    {
+      label: "WON'T BE USED - see TableActionInitializeAnswer component",
+      key: ACTION_ANSWER_INITIALIZE,
+    },
     {
       label: translate('AnswersTable.buttonEdit'),
       key: ACTION_EDIT,

--- a/src/client/components/ContractsAnswers.js
+++ b/src/client/components/ContractsAnswers.js
@@ -1,161 +1,52 @@
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import React from 'react';
 
 import ButtonOutline from '~/client/components/ButtonOutline';
 import EthereumContainer from '~/client/components/EthereumContainer';
-import translate from '~/common/services/i18n';
 import { ParagraphStyle } from '~/client/styles/typography';
-import {
-  TX_DEACTIVATE_ANSWER,
-  TX_INITIALIZE_ANSWER,
-  deactivateAnswer,
-  initializeAnswer,
-  isAnswerDeactivated,
-  isAnswerInitialized,
-} from '~/common/services/contracts/answers';
-import { addPendingTransaction } from '~/client/store/ethereum/actions';
-import {
-  usePendingTransaction,
-  useOwnerAddress,
-} from '~/client/hooks/ethereum';
+import InitializeAnswer from '~/client/components/InitializeAnswer';
+import translate from '~/common/services/i18n';
 
 const ContractsAnswers = ({
-  questionChainId,
   answerChainId,
-  setIsDeactivated,
-  isDeactivated,
+  handleDeactivate,
+  questionChainId,
 }) => {
-  const initializeTx = usePendingTransaction({
-    txMethod: TX_INITIALIZE_ANSWER,
-    params: { answerChainId },
-  });
-  const deactivateTx = usePendingTransaction({
-    txMethod: TX_DEACTIVATE_ANSWER,
-    params: { answerChainId },
-  });
-
-  const [isInitialized, setIsInitialized] = useState(false);
-
-  useEffect(() => {
-    const getInitializedStatus = async () => {
-      if (questionChainId !== '') {
-        const state = await isAnswerInitialized(questionChainId, answerChainId);
-        setIsInitialized(state);
-      }
-    };
-
-    getInitializedStatus();
-  }, [questionChainId, answerChainId, initializeTx.isPending]);
-
-  useEffect(() => {
-    const getDeactivatedStatus = async () => {
-      const state = await isAnswerDeactivated(questionChainId, answerChainId);
-      setIsDeactivated(state);
-    };
-
-    getDeactivatedStatus();
-  }, [
-    questionChainId,
-    answerChainId,
-    deactivateTx.isPending,
-    setIsDeactivated,
-  ]);
-
   return (
     <EthereumContainer>
-      {isDeactivated ? (
-        <ParagraphStyle>
-          {translate('ContractsAnswers.bodyAlreadyDeactivated')}
-        </ParagraphStyle>
-      ) : !isInitialized ? (
-        <ContractsAnswersInitialize
-          answerChainId={answerChainId}
-          questionChainId={questionChainId}
-        />
-      ) : (
-        <ContractsAnswersDeactivate
-          answerChainId={answerChainId}
-          questionChainId={questionChainId}
-        />
-      )}
+      <InitializeAnswer
+        answerChainId={answerChainId}
+        handleDeactivate={handleDeactivate}
+        questionChainId={questionChainId}
+      >
+        {({ isInitialized, isDeactivated, onInitialize, onDeactivate }) => {
+          return (
+            <>
+              {isDeactivated ? (
+                <ParagraphStyle>
+                  {translate('ContractsAnswers.bodyAlreadyDeactivated')}
+                </ParagraphStyle>
+              ) : isInitialized ? (
+                <ButtonOutline isDanger={true} onClick={onDeactivate}>
+                  {translate('ContractsAnswers.buttonDeactivateAnswer')}
+                </ButtonOutline>
+              ) : (
+                <ButtonOutline onClick={onInitialize}>
+                  {translate('ContractsAnswers.buttonInitializeAnswer')}
+                </ButtonOutline>
+              )}
+            </>
+          );
+        }}
+      </InitializeAnswer>
     </EthereumContainer>
   );
 };
 
-const ContractsAnswersInitialize = ({ questionChainId, answerChainId }) => {
-  const dispatch = useDispatch();
-  const owner = useOwnerAddress();
-
-  const onClick = async (event) => {
-    event.preventDefault();
-
-    const { txHash, txMethod } = await initializeAnswer(
-      owner,
-      questionChainId,
-      answerChainId,
-    );
-
-    dispatch(
-      addPendingTransaction({
-        txHash,
-        txMethod,
-        params: { answerChainId },
-      }),
-    );
-  };
-
-  return (
-    <ButtonOutline onClick={onClick}>
-      {translate('ContractsAnswers.buttonInitializeAnswer')}
-    </ButtonOutline>
-  );
-};
-
-const ContractsAnswersDeactivate = ({ questionChainId, answerChainId }) => {
-  const dispatch = useDispatch();
-  const owner = useOwnerAddress();
-
-  const onClick = async (event) => {
-    event.preventDefault();
-
-    const { txHash, txMethod } = await deactivateAnswer(
-      owner,
-      questionChainId,
-      answerChainId,
-    );
-
-    dispatch(
-      addPendingTransaction({
-        txHash,
-        txMethod,
-        params: { answerChainId },
-      }),
-    );
-  };
-
-  return (
-    <ButtonOutline isDanger={true} onClick={onClick}>
-      {translate('ContractsAnswers.buttonDeactivateAnswer')}
-    </ButtonOutline>
-  );
-};
-
-ContractsAnswersInitialize.propTypes = {
-  answerChainId: PropTypes.string.isRequired,
-  questionChainId: PropTypes.string.isRequired,
-};
-
-ContractsAnswersDeactivate.propTypes = {
-  answerChainId: PropTypes.string.isRequired,
-  questionChainId: PropTypes.string.isRequired,
-};
-
 ContractsAnswers.propTypes = {
   answerChainId: PropTypes.string.isRequired,
-  isDeactivated: PropTypes.bool.isRequired,
+  handleDeactivate: PropTypes.func,
   questionChainId: PropTypes.string.isRequired,
-  setIsDeactivated: PropTypes.func.isRequired,
 };
 
 export default ContractsAnswers;

--- a/src/client/components/FormAnswers.js
+++ b/src/client/components/FormAnswers.js
@@ -6,9 +6,9 @@ import InputFinderField from '~/client/components/InputFinderField';
 import InputHiddenField from '~/client/components/InputHiddenField';
 import translate from '~/common/services/i18n';
 
-const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
+const FormAnswers = ({ question, festivalId, isDisabled }) => {
   const schema = {};
-  if (!isArtworkAnswer) {
+  if (question.type === 'festival') {
     schema.artworkId = Joi.number()
       .required()
       .error(new Error(translate('validations.artworkRequired')));
@@ -19,7 +19,8 @@ const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
   }
 
   const filter = (item) => {
-    const filterParam = !isArtworkAnswer ? 'artworkId' : 'propertyId';
+    const filterParam =
+      question.type === 'festival' ? 'artworkId' : 'propertyId';
     const answerIds = question.answers.map((answer) => answer[filterParam]);
     const filtered = item.festivals.filter((festival) => {
       return festival.id === festivalId && !answerIds.includes(item.id);
@@ -35,7 +36,7 @@ const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
         value={{ value: question.id }}
       />
 
-      {!isArtworkAnswer ? (
+      {question.type === 'festival' ? (
         <InputFinderField
           clientSideFilter={filter}
           isDisabled={isDisabled}
@@ -63,7 +64,6 @@ const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
 
 FormAnswers.propTypes = {
   festivalId: PropTypes.number,
-  isArtworkAnswer: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool,
   question: PropTypes.object.isRequired,
 };

--- a/src/client/components/FormQuestions.js
+++ b/src/client/components/FormQuestions.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 
 import InputField from '~/client/components/InputField';
+import InputHiddenField from '~/client/components/InputHiddenField';
 import InputFinderField from '~/client/components/InputFinderField';
 import translate from '~/common/services/i18n';
+import { QUESTION_TYPES } from '~/common/helpers/validate';
 
 const FormQuestions = ({ isFinderDisabled, festivalId }) => {
   const hasFestival = !!festivalId;
@@ -18,6 +20,7 @@ const FormQuestions = ({ isFinderDisabled, festivalId }) => {
       .integer()
       .allow(null)
       .error(new Error(translate('validations.artworkRequired'))),
+    type: Joi.valid(...QUESTION_TYPES).required(),
   };
 
   const filter = (item) => {
@@ -58,6 +61,8 @@ const FormQuestions = ({ isFinderDisabled, festivalId }) => {
         selectParam={'id'}
         validate={schema.artworkId}
       />
+
+      <InputHiddenField name="type" value={{ value: 'festival' }} />
     </Fragment>
   );
 };

--- a/src/client/components/InitializeAnswer.js
+++ b/src/client/components/InitializeAnswer.js
@@ -1,0 +1,126 @@
+import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import {
+  TX_DEACTIVATE_ANSWER,
+  TX_INITIALIZE_ANSWER,
+  deactivateAnswer,
+  initializeAnswer,
+  isAnswerDeactivated,
+  isAnswerInitialized,
+} from '~/common/services/contracts/answers';
+import { addPendingTransaction } from '~/client/store/ethereum/actions';
+import {
+  usePendingTransaction,
+  useOwnerAddress,
+} from '~/client/hooks/ethereum';
+
+const InitializeAnswer = ({
+  questionChainId,
+  answerChainId,
+  children,
+  handleDeactivate = () => {},
+  handleInitialize = () => {},
+}) => {
+  const dispatch = useDispatch();
+  const owner = useOwnerAddress();
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [isDeactivated, setIsDeactivated] = useState(false);
+
+  const initializeTx = usePendingTransaction({
+    txMethod: TX_INITIALIZE_ANSWER,
+    params: { answerChainId },
+  });
+  const deactivateTx = usePendingTransaction({
+    txMethod: TX_DEACTIVATE_ANSWER,
+    params: { answerChainId },
+  });
+
+  useEffect(() => {
+    const getInitializedStatus = async () => {
+      if (questionChainId !== '') {
+        const state = await isAnswerInitialized(questionChainId, answerChainId);
+        setIsInitialized(state);
+        handleInitialize(state);
+      }
+    };
+
+    getInitializedStatus();
+  }, [
+    questionChainId,
+    answerChainId,
+    initializeTx.isPending,
+    handleInitialize,
+  ]);
+
+  useEffect(() => {
+    const getDeactivatedStatus = async () => {
+      const state = await isAnswerDeactivated(questionChainId, answerChainId);
+      setIsDeactivated(state);
+      handleDeactivate(state);
+    };
+
+    getDeactivatedStatus();
+  }, [
+    questionChainId,
+    answerChainId,
+    deactivateTx.isPending,
+    handleDeactivate,
+  ]);
+
+  const onInitialize = async (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const { txHash, txMethod } = await initializeAnswer(
+      owner,
+      questionChainId,
+      answerChainId,
+    );
+
+    dispatch(
+      addPendingTransaction({
+        txHash,
+        txMethod,
+        params: { answerChainId },
+      }),
+    );
+  };
+
+  const onDeactivate = async (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const { txHash, txMethod } = await deactivateAnswer(
+      owner,
+      questionChainId,
+      answerChainId,
+    );
+
+    dispatch(
+      addPendingTransaction({
+        txHash,
+        txMethod,
+        params: { answerChainId },
+      }),
+    );
+  };
+
+  return children({
+    isInitialized,
+    isDeactivated,
+    onInitialize,
+    onDeactivate,
+  });
+};
+
+InitializeAnswer.propTypes = {
+  answerChainId: PropTypes.string.isRequired,
+  children: PropTypes.func.isRequired,
+  handleDeactivate: PropTypes.func,
+  handleInitialize: PropTypes.func,
+  questionChainId: PropTypes.string.isRequired,
+};
+
+export default InitializeAnswer;

--- a/src/client/components/Table.js
+++ b/src/client/components/Table.js
@@ -6,6 +6,7 @@ import { useLocation, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
 import ButtonOutline from '~/client/components/ButtonOutline';
+import InitializeAnswer from '~/client/components/InitializeAnswer';
 import styles from '~/client/styles/variables';
 import translate from '~/common/services/i18n';
 import { getCached } from '~/client/services/cache';
@@ -24,6 +25,7 @@ export const PARAM_PAGE_INDEX = 'page';
 export const ACTION_DESTROY = Symbol('select-destroy');
 export const ACTION_EDIT = Symbol('select-edit');
 export const ACTION_SELECT = Symbol('select-action');
+export const ACTION_ANSWER_INITIALIZE = Symbol('answer-initialize-action');
 
 const DEFAULT_HEADERS = [
   {
@@ -320,7 +322,11 @@ export const TableBody = ({
             <TableBodyItems columns={columns} values={item} />
             <td>
               {actions.length !== 0 ? (
-                <TableActions actions={actions} onSelect={onSelectAction} />
+                <TableActions
+                  actions={actions}
+                  item={item}
+                  onSelect={onSelectAction}
+                />
               ) : null}
             </td>
           </tr>
@@ -360,12 +366,17 @@ export const TableBodyItems = ({ columns, values }) => {
   });
 };
 
-export const TableActions = ({ actions, onSelect }) => {
+export const TableActions = ({ actions, onSelect, item }) => {
   return actions.map((action, index) => {
     const onSelectAction = (event) => {
       event.stopPropagation();
       onSelect(action.key);
     };
+
+    if (action.key === ACTION_ANSWER_INITIALIZE)
+      return (
+        <TableActionInitializeAnswer item={item} key={`action-${index}`} />
+      );
 
     return (
       <ButtonOutline
@@ -419,6 +430,35 @@ export const TableFooter = ({
   );
 };
 
+export const TableActionInitializeAnswer = ({ item }) => {
+  return (
+    <InitializeAnswer
+      answerChainId={item.chainId}
+      questionChainId={item.question.chainId}
+    >
+      {({ isInitialized, isDeactivated, onInitialize, onDeactivate }) => {
+        return (
+          <>
+            {isDeactivated ? (
+              <DeactivatedStyle>
+                {translate('Table.answerAlreadyDeactivated')}
+              </DeactivatedStyle>
+            ) : isInitialized ? (
+              <ButtonOutline isDanger={true} onClick={onDeactivate}>
+                {translate('Table.buttonDeactivateAnswer')}
+              </ButtonOutline>
+            ) : (
+              <ButtonOutline onClick={onInitialize}>
+                {translate('Table.buttonInitializeAnswer')}
+              </ButtonOutline>
+            )}
+          </>
+        );
+      }}
+    </InitializeAnswer>
+  );
+};
+
 export const TableStyle = styled.table`
   width: 100%;
 
@@ -460,6 +500,12 @@ const TableFooterStyle = styled.tfoot`
   tr {
     margin-top: 1rem;
   }
+`;
+
+const DeactivatedStyle = styled.span`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-right: 0.5rem;
 `;
 
 const PropTypesAction = PropTypes.shape({
@@ -530,6 +576,10 @@ TableFooter.propTypes = {
   onSelect: PropTypes.func.isRequired,
   pageIndex: PropTypes.number.isRequired,
   pagesTotal: PropTypes.number.isRequired,
+};
+
+TableActionInitializeAnswer.propTypes = {
+  item: PropTypes.object.isRequired,
 };
 
 export default Table;

--- a/src/client/styles/layout.js
+++ b/src/client/styles/layout.js
@@ -53,3 +53,7 @@ export const SpacingGroupStyle = styled.div`
     margin-top: 1rem;
   }
 `;
+
+export const HelpCopyStyle = styled.div`
+  margin: 1rem 0 2rem 0;
+`;

--- a/src/client/styles/typography.js
+++ b/src/client/styles/typography.js
@@ -60,3 +60,7 @@ export const HeadingSecondaryStyle = styled.h2`
 
   line-height: 0.9;
 `;
+
+export const PreStyle = styled.pre`
+  white-space: pre-line;
+`;

--- a/src/client/views/AdminAnswersEdit.js
+++ b/src/client/views/AdminAnswersEdit.js
@@ -33,7 +33,6 @@ const AdminAnswersEdit = () => {
             <Fragment>
               <FormAnswers
                 festivalId={resource.festivalId}
-                isArtworkAnswer={!!resource.artwork}
                 isDisabled
                 question={resource.question}
               />

--- a/src/client/views/AdminAnswersEdit.js
+++ b/src/client/views/AdminAnswersEdit.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { Fragment, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import ButtonIcon from '~/client/components/ButtonIcon';
@@ -7,15 +7,12 @@ import FooterAdmin from '~/client/components/FooterAdmin';
 import FormAnswers from '~/client/components/FormAnswers';
 import HeaderAdmin from '~/client/components/HeaderAdmin';
 import ViewAdmin from '~/client/components/ViewAdmin';
-import apiRequest from '~/client/services/api';
 import translate from '~/common/services/i18n';
 import { useEditForm } from '~/client/hooks/forms';
 import DangerZone from '~/client/components/DangerZone';
 
 const AdminAnswersEdit = () => {
   const { questionId, answerId } = useParams();
-  const [isLoading, setIsLoading] = useState(true);
-  const [question, setQuestion] = useState({});
   const [isDeactivated, setIsDeactivated] = useState(false);
 
   const returnUrl = `/admin/questions/${questionId}/edit`;
@@ -26,30 +23,19 @@ const AdminAnswersEdit = () => {
     returnUrl,
   });
 
-  useEffect(() => {
-    const getQuestion = async () => {
-      const response = await apiRequest({
-        path: ['questions', questionId],
-      });
-      setQuestion(response);
-      setIsLoading(false);
-    };
-    getQuestion();
-  }, [setQuestion, setIsLoading, questionId]);
-
   return (
     <Fragment>
       <HeaderAdmin>{translate('AdminAnswersEdit.title')}</HeaderAdmin>
 
       <ViewAdmin>
         <Form>
-          {!isLoading && !isResourceLoading && resource.chainId && (
+          {!isResourceLoading && resource.chainId && (
             <Fragment>
               <FormAnswers
                 festivalId={resource.festivalId}
                 isArtworkAnswer={!!resource.artwork}
                 isDisabled
-                question={question}
+                question={resource.question}
               />
 
               {isDeactivated ? (
@@ -60,9 +46,8 @@ const AdminAnswersEdit = () => {
 
               <ContractsAnswers
                 answerChainId={resource.chainId}
-                isDeactivated={isDeactivated}
-                questionChainId={question.chainId}
-                setIsDeactivated={setIsDeactivated}
+                handleDeactivate={(state) => setIsDeactivated(state)}
+                questionChainId={resource.question.chainId}
               />
             </Fragment>
           )}

--- a/src/client/views/AdminAnswersNew.js
+++ b/src/client/views/AdminAnswersNew.js
@@ -71,7 +71,6 @@ const AdminAnswersNew = () => {
             <Fragment>
               <FormAnswers
                 festivalId={question.festivalId}
-                isArtworkAnswer={!!question.artworkId}
                 question={question}
               />
 

--- a/src/client/views/AdminEmails.js
+++ b/src/client/views/AdminEmails.js
@@ -10,7 +10,8 @@ import HeaderAdmin from '~/client/components/HeaderAdmin';
 import ViewAdmin from '~/client/components/ViewAdmin';
 import ButtonSubmit from '~/client/components/ButtonSubmit';
 import translate from '~/common/services/i18n';
-import { SpacingGroupStyle } from '~/client/styles/layout';
+import { HelpCopyStyle, SpacingGroupStyle } from '~/client/styles/layout';
+import { ParagraphStyle, PreStyle } from '~/client/styles/typography';
 import notify, {
   NotificationsTypes,
 } from '~/client/store/notifications/actions';
@@ -30,7 +31,10 @@ const AdminEmails = () => {
 
   const textareaToRecipients = (value) =>
     [
-      ...value.split('\n').reduce((memo, email) => memo.add(email), new Set()),
+      ...value
+        .split('\n')
+        .filter((line) => line !== '')
+        .reduce((memo, email) => memo.add(email), new Set()),
     ].sort();
 
   const recipientsToTextarea = (recipients, existing = []) =>
@@ -112,8 +116,15 @@ const AdminEmails = () => {
       <HeaderAdmin>{translate('AdminEmails.title')}</HeaderAdmin>
 
       <ViewAdmin>
+        <HelpCopyStyle>
+          <ParagraphStyle>{translate('AdminEmails.copy')}</ParagraphStyle>
+          <ParagraphStyle>{translate('AdminEmails.copyUpload')}</ParagraphStyle>
+          <PreStyle>{translate('AdminEmails.example')}</PreStyle>
+        </HelpCopyStyle>
+
         <Form>
           <FormScheduleEmail />
+
           <FileUpload
             accept={['text/plain', 'text/csv', 'text/x-csv']}
             uploadText={translate('AdminEmails.fileUpload')}

--- a/src/client/views/AdminQuestionsNew.js
+++ b/src/client/views/AdminQuestionsNew.js
@@ -21,9 +21,9 @@ const AdminQuestionsNew = () => {
   const {
     Form,
     setValues,
-    values: { title, festivalId },
+    values: { title, festivalId, artworkId, type },
   } = useNewForm({
-    fields: ['title', 'festivalId', 'artworkId'],
+    fields: ['title', 'festivalId', 'artworkId', 'type'],
     resourcePath: ['questions'],
     returnUrl,
     onSuccess: ({ title }) => {
@@ -52,9 +52,16 @@ const AdminQuestionsNew = () => {
   useEffect(() => {
     if (festivalId != festivalIdCache) {
       setFestivalIdCache(festivalId);
-      setValues({ title, festivalId, artworkId: null });
+      setValues({ title, festivalId, type: 'festival', artworkId: undefined });
     }
-  }, [setValues, title, festivalId, festivalIdCache]);
+  }, [setValues, title, festivalId, type, festivalIdCache]);
+
+  // Switch over the type of the question to an artwork question once we set an artwork.
+  useEffect(() => {
+    if (artworkId != null) {
+      setValues({ title, festivalId, artworkId, type: 'artwork' });
+    }
+  }, [setValues, title, festivalId, artworkId]);
 
   return (
     <Fragment>

--- a/src/common/helpers/validate.js
+++ b/src/common/helpers/validate.js
@@ -3,6 +3,7 @@ import { Joi } from 'celebrate';
 import web3 from '~/common/services/web3';
 
 export const VOTEWEIGHT_TYPES = ['location', 'hotspot', 'organisation'];
+export const QUESTION_TYPES = ['festival', 'artwork'];
 
 // Attachements validations
 

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -319,6 +319,12 @@ const views = {
     title: 'Questions',
   },
   AdminEmails: {
+    copy: `You can add recipients by inserting emails into the text box below, one email per line.`,
+    copyUpload: `Or, upload a text file containing email addresses, again one email per line. Optionally, you can use the first line of the file as a header. For example this is a valid file to upload:`,
+    example: `Emails
+aaa@example.org
+bbb@example.org
+ccc@example.org`,
     buttonSendEmails: 'Schedule Emails',
     title: 'Schedule Email',
     notificationSuccess: 'Scheduled {amount} emails.',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -187,6 +187,9 @@ const components = {
     bodyLoading: 'Loading ...',
     columnCreatedAt: 'Created at',
     columnUpdatedAt: 'Updated at',
+    answerAlreadyDeactivated: 'Deactivated',
+    buttonDeactivateAnswer: 'Deactivate',
+    buttonInitializeAnswer: 'Initialize',
   },
   VoteCreditsBar: {
     voteCredits: 'Vote Credits',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -319,7 +319,7 @@ const views = {
     title: 'Questions',
   },
   AdminEmails: {
-    copy: `You can add recipients by inserting emails into the text box below, one email per line.`,
+    copy: `You can add recipients in the text box below, one email per line.`,
     copyUpload: `Or, upload a text file containing email addresses, again one email per line. Optionally, you can use the first line of the file as a header. For example this is a valid file to upload:`,
     example: `Emails
 aaa@example.org

--- a/src/server/controllers/answers.js
+++ b/src/server/controllers/answers.js
@@ -36,7 +36,7 @@ const readOptions = {
     {
       association: AnswerBelongsToQuestion,
       destroyCascade: false,
-      fields: ['title'],
+      fields: ['title', 'type'],
       fieldsProtected: ['chainId'],
     },
   ],

--- a/src/server/controllers/answers.js
+++ b/src/server/controllers/answers.js
@@ -3,14 +3,42 @@ import baseController from '~/server/controllers';
 import {
   AnswerBelongsToArtwork,
   AnswerBelongsToProperty,
+  AnswerBelongsToQuestion,
 } from '~/server/database/associations';
 
 import { answerFields } from '~/server/database/associations';
 
 const options = {
   model: Answer,
-  fields: [...answerFields, 'artwork', 'property'],
+  fields: [...answerFields, 'artwork', 'property', 'question'],
   fieldsProtected: ['chainId'],
+};
+
+const readOptions = {
+  ...options,
+
+  include: [
+    AnswerBelongsToProperty,
+    AnswerBelongsToArtwork,
+    AnswerBelongsToQuestion,
+  ],
+  associations: [
+    {
+      association: AnswerBelongsToProperty,
+      destroyCascade: false,
+      fields: ['title'],
+    },
+    {
+      association: AnswerBelongsToArtwork,
+      destroyCascade: false,
+      fields: ['title'],
+    },
+    {
+      association: AnswerBelongsToQuestion,
+      destroyCascade: false,
+      fields: ['title', 'chainId'],
+    },
+  ],
 };
 
 function create(req, res, next) {
@@ -19,26 +47,13 @@ function create(req, res, next) {
 
 function readAll(req, res, next) {
   baseController.readAll({
-    ...options,
+    ...readOptions,
     where: req.locals && req.locals.query,
-    include: [AnswerBelongsToProperty, AnswerBelongsToArtwork],
-    associations: [
-      {
-        association: AnswerBelongsToProperty,
-        destroyCascade: false,
-        fields: ['title'],
-      },
-      {
-        association: AnswerBelongsToArtwork,
-        destroyCascade: false,
-        fields: ['title'],
-      },
-    ],
   })(req, res, next);
 }
 
 function read(req, res, next) {
-  baseController.read(options)(req, res, next);
+  baseController.read(readOptions)(req, res, next);
 }
 
 function destroy(req, res, next) {

--- a/src/server/controllers/answers.js
+++ b/src/server/controllers/answers.js
@@ -36,7 +36,8 @@ const readOptions = {
     {
       association: AnswerBelongsToQuestion,
       destroyCascade: false,
-      fields: ['title', 'chainId'],
+      fields: ['title'],
+      fieldsProtected: ['chainId'],
     },
   ],
 };

--- a/src/server/database/associations.js
+++ b/src/server/database/associations.js
@@ -50,7 +50,13 @@ export const imageFileFields = [
 ];
 export const organisationFields = ['description', 'name'];
 export const propertyFields = ['title'];
-export const questionFields = ['title', 'chainId', 'artworkId', 'festivalId'];
+export const questionFields = [
+  'title',
+  'chainId',
+  'artworkId',
+  'festivalId',
+  'type',
+];
 export const userFields = ['username', 'email'];
 export const voteFields = [
   'boothAddress',

--- a/src/server/database/migrations/20210305154232-add-type-to-question.js
+++ b/src/server/database/migrations/20210305154232-add-type-to-question.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const QUESTION_TYPES = ['festival', 'artwork'];
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn('questions', 'type', {
+        type: Sequelize.ENUM,
+        values: QUESTION_TYPES,
+        transaction,
+      });
+      await queryInterface.sequelize.query(
+        `UPDATE questions SET type = (CASE WHEN "artworkId" IS NULL THEN 'festival'::enum_questions_type ELSE 'artwork'::enum_questions_type END)`,
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE questions ALTER COLUMN type SET NOT NULL`,
+      );
+      await queryInterface.addIndex('questions', ['festivalId', 'type'], {
+        unique: true,
+        where: {
+          type: 'festival',
+        },
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeIndex('questions', ['festivalId', 'type'], {
+        transaction,
+      });
+      await queryInterface.removeColumn('questions', 'type', { transaction });
+      await queryInterface.dropEnum('enum_questions_type', { transaction });
+    });
+  },
+};

--- a/src/server/models/question.js
+++ b/src/server/models/question.js
@@ -1,45 +1,64 @@
 import SequelizeSlugify from 'sequelize-slugify';
 import { DataTypes } from 'sequelize';
-import { generateHashSecret } from '~/server/services/crypto';
 
+import { generateHashSecret } from '~/server/services/crypto';
+import { QUESTION_TYPES } from '~/common/helpers/validate';
 import db from '~/server/database';
 
-const Question = db.define('question', {
-  id: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  chainId: {
-    type: DataTypes.STRING,
-    unique: true,
-    validate: {
-      isAlphanumeric: true,
+const Question = db.define(
+  'question',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    chainId: {
+      type: DataTypes.STRING,
+      unique: true,
+      validate: {
+        isAlphanumeric: true,
+      },
+    },
+    secret: {
+      type: DataTypes.STRING,
+      unique: true,
+      validate: {
+        isAlphanumeric: true,
+      },
+    },
+    slug: {
+      type: DataTypes.STRING,
+    },
+    title: {
+      type: DataTypes.STRING,
+    },
+    festivalId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    artworkId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    type: {
+      type: DataTypes.ENUM,
+      values: QUESTION_TYPES,
     },
   },
-  secret: {
-    type: DataTypes.STRING,
-    unique: true,
-    validate: {
-      isAlphanumeric: true,
-    },
+  {
+    indexes: [
+      {
+        unique: true,
+        fields: ['festivalId', 'type'],
+        where: {
+          type: 'festival',
+        },
+      },
+    ],
   },
-  slug: {
-    type: DataTypes.STRING,
-  },
-  title: {
-    type: DataTypes.STRING,
-  },
-  festivalId: {
-    type: DataTypes.INTEGER,
-    allowNull: true,
-  },
-  artworkId: {
-    type: DataTypes.INTEGER,
-    allowNull: true,
-  },
-});
+);
 
 SequelizeSlugify.slugifyModel(Question, {
   source: ['title'],

--- a/src/server/validations/questions.js
+++ b/src/server/validations/questions.js
@@ -1,11 +1,20 @@
 import { Joi, Segments } from 'celebrate';
 
 import { idValidation, paginationValidation } from '~/server/validations';
+import { QUESTION_TYPES } from '~/common/helpers/validate';
 
 const defaultValidation = {
   artworkId: Joi.number().integer().allow(null),
   festivalId: Joi.number().integer().required(),
   title: Joi.string().max(128).required(),
+  type: Joi.alternatives()
+    .conditional('artworkId', {
+      is: undefined,
+      then: Joi.custom(() => 'festival'),
+      otherwise: Joi.custom(() => 'artwork'),
+    })
+    .valid(...QUESTION_TYPES)
+    .required(),
 };
 
 export default {

--- a/test/answers.test.js
+++ b/test/answers.test.js
@@ -30,11 +30,13 @@ describe('Answers', () => {
 
     questionData1 = await put('/api/questions', {
       title: 'Why is this necessary?',
+      type: 'festival',
       festivalId: festivalData.id,
     });
 
     questionData2 = await put('/api/questions', {
       title: 'How many?',
+      type: 'artwork',
       artworkId: artworkData.id,
       festivalId: festivalData.id,
     });

--- a/test/booths.test.js
+++ b/test/booths.test.js
@@ -53,6 +53,7 @@ describe('Voting booth', () => {
     festivalQuestionData = await put('/api/questions', {
       title: 'What do you think about dogs?',
       festivalId: festivalData.id,
+      type: 'festival',
     });
 
     // Set up question contract
@@ -60,6 +61,7 @@ describe('Voting booth', () => {
       title: 'What and how much?',
       festivalId: festivalData.id,
       artworkId: artworkIds[0], // Create artwork question for Davinci
+      type: 'artwork',
     });
 
     // Add answers to API

--- a/test/data/questions.json
+++ b/test/data/questions.json
@@ -1,8 +1,10 @@
 {
   "questionFestival": {
-    "title": "what do you think about frogs?"
+    "title": "what do you think about frogs?",
+    "type": "festival"
   },
   "questionArtwork": {
-    "title": "what planet do we live on?"
+    "title": "what planet do we live on?",
+    "type": "artwork"
   }
 }

--- a/test/questions.test.js
+++ b/test/questions.test.js
@@ -29,9 +29,21 @@ describe('Questions', () => {
         .put('/api/questions')
         .send({
           title: 'What was your favorite artwork of this festival?',
+          type: 'festival',
           festivalId: festivalData.id,
         })
         .expect(httpStatus.CREATED);
+    });
+
+    it('should fail creating two questions for a single festival', async () => {
+      await authRequest
+        .put('/api/questions')
+        .send({
+          title: 'What was your favorite artwork of this festival?',
+          type: 'festival',
+          festivalId: festivalData.id,
+        })
+        .expect(httpStatus.CONFLICT);
     });
   });
 
@@ -42,7 +54,9 @@ describe('Questions', () => {
     beforeAll(async () => {
       questionData = await put('/api/questions', {
         title: 'What is your favorite color?',
+        type: 'artwork',
         festivalId: festivalData.id,
+        artworkId: artworkData.id,
       });
 
       answerData = await put('/api/answers', {

--- a/test/results.test.js
+++ b/test/results.test.js
@@ -102,6 +102,7 @@ describe('Vote results', () => {
     festivalQuestionData = await put('/api/questions', {
       title: 'What do you think about frogs?',
       festivalId: festivalData.id,
+      type: 'festival',
     });
     const festivalQuestionAddress = await initQuestion(
       adminContract,
@@ -117,6 +118,7 @@ describe('Vote results', () => {
       title: 'What aspect of this frogwork did you like and how much?',
       festivalId: festivalData.id,
       artworkId: artworkIds[0], // Create artwork question for Davinci
+      type: 'artwork',
     });
     const artworkQuestionAddress = await initQuestion(
       adminContract,

--- a/test/vote.test.js
+++ b/test/vote.test.js
@@ -84,6 +84,7 @@ describe('Vote', () => {
       // Set up first question contract for artwork answers on an festival
       const festivalQuestionData = await put('/api/questions', {
         title: 'What was your favorite artwork of this festival?',
+        type: 'festival',
         festivalId: festivalData.id,
       });
 
@@ -97,6 +98,7 @@ describe('Vote', () => {
       // Set up second question contract for property answers on an artwork
       const artworkQuestionData = await put('/api/questions', {
         title: 'What aspect of this artwork did you like and how much?',
+        type: 'artwork',
         festivalId: festivalData.id,
         artworkId: artworkData.id,
       });

--- a/test/vote.test.js
+++ b/test/vote.test.js
@@ -58,29 +58,35 @@ describe('Vote', () => {
     // Add test data
     artworkData = await put('/api/artworks', artworksData.davinci);
     propertyData = await put('/api/properties', propertiesData.aProperty);
-    festivalData = await put('/api/festivals', festivalsData.barbeque);
-
-    // Use chainId from contract migrations
-    festivalData.chainId = web3.utils.sha3('festival');
-    const festivalInitialized = await isFestivalInitialized(
-      festivalData.chainId,
-    );
-    if (!festivalInitialized) {
-      await initFestival(
-        adminContract,
-        festivalData.chainId,
-        timestamp() + 20,
-        timestamp() + 100000,
-      );
-    }
-    const boothInitialized = await isVotingBoothInitialized(booth.address);
-    if (!boothInitialized) {
-      await initVotingBooth(adminContract, festivalData.chainId, booth.address);
-    }
   });
 
   describe('POST /api/votes', () => {
     beforeEach(async () => {
+      // Add test data
+      festivalData = await put('/api/festivals', festivalsData.barbeque);
+
+      // Use chainId from contract migrations
+      festivalData.chainId = web3.utils.sha3('festival');
+      const festivalInitialized = await isFestivalInitialized(
+        festivalData.chainId,
+      );
+      if (!festivalInitialized) {
+        await initFestival(
+          adminContract,
+          festivalData.chainId,
+          timestamp() + 20,
+          timestamp() + 100000,
+        );
+      }
+      const boothInitialized = await isVotingBoothInitialized(booth.address);
+      if (!boothInitialized) {
+        await initVotingBooth(
+          adminContract,
+          festivalData.chainId,
+          booth.address,
+        );
+      }
+
       // Set up first question contract for artwork answers on an festival
       const festivalQuestionData = await put('/api/questions', {
         title: 'What was your favorite artwork of this festival?',


### PR DESCRIPTION
closes #115 

Answers can be initialized at two places now, inline of the answers
table on the question view and on the edit answer view, the same as
before. I kept the edit page intact since we also use that view to
delete answers.

In order to reduce code duplication I created a new `InitializeAnswer`
components whose purpose it is to manage the logic of initializing
answers. That component is used on the answers table as well as on the
edit answers view. It manages the logic and calls a render
prop (`children`) as a function to render the UI itself.

The table implementation is very limited and doesn't allow for inline
actions (and from what I can tell neither multiple actions on a table
row). I created special support for an `ACTION_ANSWER_INITILIAZE` table
action that is treated special inside the table. If we ever have to
support more inline actions we might want to refactor this approach.

Having multiple actions leads in this case to a rather ugly line break
of the action buttons. Shortening the `Deactivate` label by one
character would solve the problem. Otherwise we need to edit the styles
of the `ButtonOutline` component. I didn't want to do that for this case
since I'm not totally certain of the repercussions to the styling of the
rest of the page.

![Screen Shot 2021-03-10 at 16 51 43](https://user-images.githubusercontent.com/29301569/110657171-85948200-81b8-11eb-9864-c8bf62ee97f8.png)
