### PR TITLE
Vote weights buttons

### DIFF
--- a/src/client/components/VoteweightsContainer.js
+++ b/src/client/components/VoteweightsContainer.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import Table, { ACTION_DESTROY } from '~/client/components/Table';
+import Table, { ACTION_EDIT } from '~/client/components/Table';
 import translate from '~/common/services/i18n';
-import { destroyRequest } from '~/client/store/api/actions';
+import { getRequest } from '~/client/store/api/actions';
 import { HeadingSecondaryStyle } from '~/client/styles/typography';
 import styles from '~/client/styles/variables';
 import swirl from '~/client/assets/images/swirl.svg';
@@ -16,9 +17,8 @@ const table = {
   path: ['voteweights'],
   actions: [
     {
-      label: translate('VoteweightsTable.buttonDelete'),
-      isDangerous: true,
-      key: ACTION_DESTROY,
+      label: translate('VoteweightsTable.buttonEdit'),
+      key: ACTION_EDIT,
     },
   ],
   columns: [
@@ -37,15 +37,14 @@ const table = {
 
 const VoteweightsContainer = ({ festivalId }) => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const { slug } = useParams();
 
   const onSelect = ({ item }) => {
-    if (!window.confirm(translate('default.areYouSure'))) {
-      return;
-    }
+    history.push(`/admin/festivals/${slug}/voteweights/${item.id}/edit`);
 
     dispatch(
-      destroyRequest({
+      getRequest({
         path: ['voteweights', item.id],
       }),
     );

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -31,6 +31,7 @@ import AdminUsers from '~/client/views/AdminUsers';
 import AdminUsersEdit from '~/client/views/AdminUsersEdit';
 import AdminUsersNew from '~/client/views/AdminUsersNew';
 import AdminVoteweightsNew from '~/client/views/AdminVoteweightsNew';
+import AdminVoteweightsEdit from '~/client/views/AdminVoteweightsEdit';
 import Artworks from '~/client/views/Artworks';
 import ArtworksProfile from '~/client/views/ArtworksProfile';
 import Booth from '~/client/views/Booth';
@@ -172,6 +173,11 @@ const Routes = () => (
       component={AdminVoteweightsNew}
       exact
       path="/admin/festivals/:slug/voteweights/new"
+    />
+    <AuthenticatedRoute
+      component={AdminVoteweightsEdit}
+      exact
+      path="/admin/festivals/:slug/voteweights/:voteweightId/edit"
     />
     <AuthenticatedRoute
       component={AdminQuestions}

--- a/src/client/views/AdminVoteweightsEdit.js
+++ b/src/client/views/AdminVoteweightsEdit.js
@@ -1,0 +1,127 @@
+import React, { Fragment, useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+
+import ButtonIcon from '~/client/components/ButtonIcon';
+import ButtonSubmit from '~/client/components/ButtonSubmit';
+import DangerZone from '~/client/components/DangerZone';
+import FooterAdmin from '~/client/components/FooterAdmin';
+import FormVoteweights from '~/client/components/FormVoteweights';
+import HeaderAdmin from '~/client/components/HeaderAdmin';
+import ViewAdmin from '~/client/components/ViewAdmin';
+import apiRequest from '~/client/services/api';
+import notify, {
+  NotificationsTypes,
+} from '~/client/store/notifications/actions';
+import translate from '~/common/services/i18n';
+import { useEditForm } from '~/client/hooks/forms';
+
+const AdminVoteweightsEdit = () => {
+  const dispatch = useDispatch();
+  const { slug } = useParams();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [festival, setFestival] = useState({});
+  const [type, setType] = useState('location');
+
+  const returnUrl = `/admin/festivals/${slug}/edit`;
+
+  useEffect(() => {
+    const getFestival = async () => {
+      const response = await apiRequest({
+        path: ['festivals', slug],
+      });
+
+      setFestival(response);
+      setIsLoading(false);
+    };
+
+    getFestival();
+  }, [setFestival, setIsLoading, slug]);
+
+  const { ButtonDelete, Form } = useEditForm({
+    fields: [
+      'festivalId',
+      'name',
+      'multiplier',
+      'type',
+      'latitude',
+      'longitude',
+      'radius',
+      'hotspot',
+      'organisationId',
+    ],
+    resourcePath: ['voteweights', slug],
+    returnUrl,
+    onNotFound: () => {
+      dispatch(
+        notify({
+          text: translate('AdminVoteweightsEdit.errorNotFound'),
+        }),
+      );
+    },
+    onDeleteSuccess: ({ name }) => {
+      dispatch(
+        notify({
+          text: translate('AdminVoteweightsEdit.notificationDestroySuccess', {
+            name,
+          }),
+        }),
+      );
+    },
+    onUpdateSuccess: ({ name }) => {
+      dispatch(
+        notify({
+          text: translate('AdminVoteweightsEdit.notificationSuccess', {
+            name,
+          }),
+        }),
+      );
+    },
+    onUpdateError: () => {
+      dispatch(
+        notify({
+          text: translate('default.errorMessage'),
+          type: NotificationsTypes.ERROR,
+        }),
+      );
+    },
+  });
+
+  const onChange = (event) => {
+    event.preventDefault();
+    setType(event.target.value);
+  };
+
+  return (
+    <Fragment>
+      <HeaderAdmin>{translate('AdminVoteweightsEdit.title')}</HeaderAdmin>
+
+      <ViewAdmin>
+        <Form>
+          {!isLoading && festival ? (
+            <Fragment>
+              <FormVoteweights
+                festival={festival}
+                type={type}
+                onChange={onChange}
+              />
+              <DangerZone>
+                <ButtonDelete />
+              </DangerZone>
+              <ButtonSubmit />
+            </Fragment>
+          ) : null}
+        </Form>
+      </ViewAdmin>
+
+      <FooterAdmin>
+        <ButtonIcon isIconFlipped to={returnUrl}>
+          {translate('AdminVoteweightsEdit.buttonBackToFestival')}
+        </ButtonIcon>
+      </FooterAdmin>
+    </Fragment>
+  );
+};
+
+export default AdminVoteweightsEdit;

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -229,6 +229,7 @@ const components = {
   },
   VoteweightsTable: {
     buttonDelete: 'Delete',
+    buttonEdit: 'Edit',
     fieldType: 'Type',
     fieldName: 'Name',
   },
@@ -407,6 +408,14 @@ const views = {
   AdminVoteweightsNew: {
     notificationSuccess: 'You created a new vote weight.',
     title: 'Create new vote weight',
+    fieldName: 'Name',
+  },
+  AdminVoteweightsEdit: {
+    errorNotFound: 'This voteweight does not exist.',
+    notificationDestroySuccess: 'You deleted the voteweight {name}.',
+    notificationSuccess: 'You edited the voteweight {name}.',
+    title: 'Edit vote weight',
+    buttonBackToFestival: 'Back to festival',
   },
   Artworks: {
     buttonBackToFestival: 'Back to festival',

--- a/src/server/controllers/voteweights.js
+++ b/src/server/controllers/voteweights.js
@@ -13,6 +13,10 @@ function create(req, res, next) {
   baseController.create(options)(req, res, next);
 }
 
+function update(req, res, next) {
+  baseController.update(options)(req, res, next);
+}
+
 function readAll(req, res, next) {
   baseController.readAll({
     ...options,
@@ -30,6 +34,7 @@ function destroy(req, res, next) {
 
 export default {
   create,
+  update,
   read,
   readAll,
   destroy,

--- a/src/server/routes/voteweights.js
+++ b/src/server/routes/voteweights.js
@@ -27,6 +27,15 @@ router.put(
   voteweightsController.create,
 );
 
+router.post(
+  '/:id',
+  authMiddleware,
+  validate(voteweightsValidation.update),
+  locationsMiddleware,
+  getVoteweightResource,
+  voteweightsController.update,
+);
+
 router.get(
   '/',
   optionalAuthMiddleware,


### PR DESCRIPTION
These commits change the 'delete' button in the voteweights container to 'edit', which when clicked returns a voteweight edit view that allows the user to change the parameters of a voteweight, or delete it.

One small problem still remains: on successful update or deletion of a voteweight, the 'success' or 'destroy' message translation doesn't find the 'name' of the voteweight, so return's e.g. 'You deleted the voteweight {name}'.