### PR TITLE
Fix updating a question.

### DIFF
--- a/src/server/validations/questions.js
+++ b/src/server/validations/questions.js
@@ -7,6 +7,10 @@ const defaultValidation = {
   artworkId: Joi.number().integer().allow(null),
   festivalId: Joi.number().integer().required(),
   title: Joi.string().max(128).required(),
+};
+
+const createValidation = {
+  ...defaultValidation,
   type: Joi.alternatives()
     .conditional('artworkId', {
       is: undefined,
@@ -20,7 +24,7 @@ const defaultValidation = {
 export default {
   create: {
     [Segments.BODY]: {
-      ...defaultValidation,
+      ...createValidation,
     },
   },
   readAll: {


### PR DESCRIPTION
This commit removes the question type from the validation when updating
a question. The UI sends the question type only during creation of the
question. I assume that questions can't be switched between being a
festival question and artwork question.