### PR TITLE
Create a question inline during festival creation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18097,6 +18097,17 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
+      "requires": {
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
     "redis-commands": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",
     "react-three-fiber": "^4.2.20",
+    "redis": "^3.0.2",
     "redux": "^4.0.5",
     "redux-create-action-types": "^2.1.0",
     "redux-logger": "^3.0.6",

--- a/src/client/components/AnswersTable.js
+++ b/src/client/components/AnswersTable.js
@@ -3,12 +3,19 @@ import React from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
-import Table, { ACTION_EDIT } from '~/client/components/Table';
+import Table, {
+  ACTION_ANSWER_INITIALIZE,
+  ACTION_EDIT,
+} from '~/client/components/Table';
 import translate from '~/common/services/i18n';
 
 const table = {
   path: ['answers'],
   actions: [
+    {
+      label: "WON'T BE USED - see TableActionInitializeAnswer component",
+      key: ACTION_ANSWER_INITIALIZE,
+    },
     {
       label: translate('AnswersTable.buttonEdit'),
       key: ACTION_EDIT,

--- a/src/client/components/ContractsAnswers.js
+++ b/src/client/components/ContractsAnswers.js
@@ -1,161 +1,52 @@
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import React from 'react';
 
 import ButtonOutline from '~/client/components/ButtonOutline';
 import EthereumContainer from '~/client/components/EthereumContainer';
-import translate from '~/common/services/i18n';
 import { ParagraphStyle } from '~/client/styles/typography';
-import {
-  TX_DEACTIVATE_ANSWER,
-  TX_INITIALIZE_ANSWER,
-  deactivateAnswer,
-  initializeAnswer,
-  isAnswerDeactivated,
-  isAnswerInitialized,
-} from '~/common/services/contracts/answers';
-import { addPendingTransaction } from '~/client/store/ethereum/actions';
-import {
-  usePendingTransaction,
-  useOwnerAddress,
-} from '~/client/hooks/ethereum';
+import InitializeAnswer from '~/client/components/InitializeAnswer';
+import translate from '~/common/services/i18n';
 
 const ContractsAnswers = ({
-  questionChainId,
   answerChainId,
-  setIsDeactivated,
-  isDeactivated,
+  handleDeactivate,
+  questionChainId,
 }) => {
-  const initializeTx = usePendingTransaction({
-    txMethod: TX_INITIALIZE_ANSWER,
-    params: { answerChainId },
-  });
-  const deactivateTx = usePendingTransaction({
-    txMethod: TX_DEACTIVATE_ANSWER,
-    params: { answerChainId },
-  });
-
-  const [isInitialized, setIsInitialized] = useState(false);
-
-  useEffect(() => {
-    const getInitializedStatus = async () => {
-      if (questionChainId !== '') {
-        const state = await isAnswerInitialized(questionChainId, answerChainId);
-        setIsInitialized(state);
-      }
-    };
-
-    getInitializedStatus();
-  }, [questionChainId, answerChainId, initializeTx.isPending]);
-
-  useEffect(() => {
-    const getDeactivatedStatus = async () => {
-      const state = await isAnswerDeactivated(questionChainId, answerChainId);
-      setIsDeactivated(state);
-    };
-
-    getDeactivatedStatus();
-  }, [
-    questionChainId,
-    answerChainId,
-    deactivateTx.isPending,
-    setIsDeactivated,
-  ]);
-
   return (
     <EthereumContainer>
-      {isDeactivated ? (
-        <ParagraphStyle>
-          {translate('ContractsAnswers.bodyAlreadyDeactivated')}
-        </ParagraphStyle>
-      ) : !isInitialized ? (
-        <ContractsAnswersInitialize
-          answerChainId={answerChainId}
-          questionChainId={questionChainId}
-        />
-      ) : (
-        <ContractsAnswersDeactivate
-          answerChainId={answerChainId}
-          questionChainId={questionChainId}
-        />
-      )}
+      <InitializeAnswer
+        answerChainId={answerChainId}
+        handleDeactivate={handleDeactivate}
+        questionChainId={questionChainId}
+      >
+        {({ isInitialized, isDeactivated, onInitialize, onDeactivate }) => {
+          return (
+            <>
+              {isDeactivated ? (
+                <ParagraphStyle>
+                  {translate('ContractsAnswers.bodyAlreadyDeactivated')}
+                </ParagraphStyle>
+              ) : isInitialized ? (
+                <ButtonOutline isDanger={true} onClick={onDeactivate}>
+                  {translate('ContractsAnswers.buttonDeactivateAnswer')}
+                </ButtonOutline>
+              ) : (
+                <ButtonOutline onClick={onInitialize}>
+                  {translate('ContractsAnswers.buttonInitializeAnswer')}
+                </ButtonOutline>
+              )}
+            </>
+          );
+        }}
+      </InitializeAnswer>
     </EthereumContainer>
   );
 };
 
-const ContractsAnswersInitialize = ({ questionChainId, answerChainId }) => {
-  const dispatch = useDispatch();
-  const owner = useOwnerAddress();
-
-  const onClick = async (event) => {
-    event.preventDefault();
-
-    const { txHash, txMethod } = await initializeAnswer(
-      owner,
-      questionChainId,
-      answerChainId,
-    );
-
-    dispatch(
-      addPendingTransaction({
-        txHash,
-        txMethod,
-        params: { answerChainId },
-      }),
-    );
-  };
-
-  return (
-    <ButtonOutline onClick={onClick}>
-      {translate('ContractsAnswers.buttonInitializeAnswer')}
-    </ButtonOutline>
-  );
-};
-
-const ContractsAnswersDeactivate = ({ questionChainId, answerChainId }) => {
-  const dispatch = useDispatch();
-  const owner = useOwnerAddress();
-
-  const onClick = async (event) => {
-    event.preventDefault();
-
-    const { txHash, txMethod } = await deactivateAnswer(
-      owner,
-      questionChainId,
-      answerChainId,
-    );
-
-    dispatch(
-      addPendingTransaction({
-        txHash,
-        txMethod,
-        params: { answerChainId },
-      }),
-    );
-  };
-
-  return (
-    <ButtonOutline isDanger={true} onClick={onClick}>
-      {translate('ContractsAnswers.buttonDeactivateAnswer')}
-    </ButtonOutline>
-  );
-};
-
-ContractsAnswersInitialize.propTypes = {
-  answerChainId: PropTypes.string.isRequired,
-  questionChainId: PropTypes.string.isRequired,
-};
-
-ContractsAnswersDeactivate.propTypes = {
-  answerChainId: PropTypes.string.isRequired,
-  questionChainId: PropTypes.string.isRequired,
-};
-
 ContractsAnswers.propTypes = {
   answerChainId: PropTypes.string.isRequired,
-  isDeactivated: PropTypes.bool.isRequired,
+  handleDeactivate: PropTypes.func,
   questionChainId: PropTypes.string.isRequired,
-  setIsDeactivated: PropTypes.func.isRequired,
 };
 
 export default ContractsAnswers;

--- a/src/client/components/ContractsEmailSigner.js
+++ b/src/client/components/ContractsEmailSigner.js
@@ -1,0 +1,147 @@
+import React, { Fragment } from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import ButtonSubmit from '~/client/components/ButtonSubmit';
+import EthereumContainer from '~/client/components/EthereumContainer';
+import InputHiddenField from '~/client/components/InputHiddenField';
+import Pill from '~/client/components/Pill';
+import notify, {
+  NotificationsTypes,
+} from '~/client/store/notifications/actions';
+import InputFinderField from '~/client/components/InputFinderField';
+import { initializeVotingBooth } from '~/common/services/contracts/booths';
+import { isFestivalInitialized } from '~/common/services/contracts/festivals';
+import translate from '~/common/services/i18n';
+import { addPendingTransaction } from '~/client/store/ethereum/actions';
+import { useContractsForm } from '~/client/hooks/forms';
+import { useOwnerAddress } from '~/client/hooks/ethereum';
+import { web3Validators } from '~/common/helpers/validate';
+import { ParagraphStyle } from '~/client/styles/typography';
+import { initializeBooth, resetBooth } from '~/client/store/booth/actions';
+import ButtonOutline from '~/client/components/ButtonOutline';
+
+const boothAddressSchema = web3Validators.web3().address().required();
+const festivalChainIdSchema = web3Validators.web3().sha3().required();
+
+const ContractsEmailSigner = ({
+  booth,
+  isReadyToSign = false,
+  setFestival,
+}) => {
+  return (
+    <EthereumContainer>
+      {isReadyToSign ? (
+        <ParagraphStyle>
+          {translate('ContractsEmailSigner.finishTitle')}
+        </ParagraphStyle>
+      ) : (
+        <ParagraphStyle>
+          {translate('ContractsEmailSigner.startTitle')}
+        </ParagraphStyle>
+      )}
+
+      <ContractsBoothsForm booth={booth} setFestival={setFestival} />
+    </EthereumContainer>
+  );
+};
+
+const ContractsBoothsForm = ({ booth, setFestival }) => {
+  const dispatch = useDispatch();
+  const owner = useOwnerAddress();
+
+  const onCreateBooth = () => {
+    dispatch(initializeBooth());
+  };
+
+  const onBurnBooth = () => {
+    if (!window.confirm(translate('default.areYouSure'))) {
+      return;
+    }
+
+    dispatch(resetBooth());
+  };
+
+  const { Form, meta, reset } = useContractsForm({
+    onSubmit: async ({ boothAddress, festivalChainId }) => {
+      const festivalInitialized = await isFestivalInitialized(festivalChainId);
+      if (!festivalInitialized) {
+        dispatch(
+          notify({
+            text: translate('ContractsEmailSigner.errorNotInitialized'),
+            type: NotificationsTypes.ERROR,
+          }),
+        );
+        reset();
+        return;
+      }
+      const { txHash, txMethod } = await initializeVotingBooth(
+        owner,
+        festivalChainId,
+        boothAddress,
+      );
+
+      dispatch(
+        addPendingTransaction({
+          txHash,
+          txMethod,
+        }),
+      );
+      reset();
+
+      return;
+    },
+  });
+
+  return booth.address && !booth.isInitialized && !booth.isDeactivated ? (
+    <Form>
+      <InputHiddenField
+        label={translate('ContractsEmailSigner.fieldBoothAddress')}
+        name="boothAddress"
+        validate={boothAddressSchema}
+        value={{ value: booth.address }}
+      />
+
+      <InputFinderField
+        label={translate('ContractsEmailSigner.fieldFestivalChainId')}
+        name="festivalChainId"
+        placeholder={translate('ContractsEmailSigner.fieldFestivalPlaceholder')}
+        queryPath={['festivals']}
+        searchParam={'title'}
+        selectParam={'chainId'}
+        validate={festivalChainIdSchema}
+        onChangeCallback={setFestival}
+      />
+
+      <ButtonSubmit disabled={meta.request.isPending}>
+        {translate('ContractsEmailSigner.buttonAddNewBooth')}
+      </ButtonSubmit>
+    </Form>
+  ) : booth.isInitialized ? (
+    <Fragment>
+      <ParagraphStyle>
+        <Pill>{booth.address}</Pill>
+      </ParagraphStyle>
+      <ButtonOutline isDanger={true} onClick={onBurnBooth}>
+        {translate('ContractsEmailSigner.buttonBurnBooth')}
+      </ButtonOutline>
+    </Fragment>
+  ) : (
+    <ButtonOutline onClick={onCreateBooth}>
+      {translate('ContractsEmailSigner.buttonInitializeBooth')}
+    </ButtonOutline>
+  );
+};
+
+ContractsEmailSigner.propTypes = {
+  booth: PropTypes.object.isRequired,
+  isReadyToSign: PropTypes.bool,
+  setFestival: PropTypes.func.isRequired,
+};
+
+ContractsBoothsForm.propTypes = {
+  booth: PropTypes.object.isRequired,
+  setFestival: PropTypes.func.isRequired,
+};
+
+export default ContractsEmailSigner;

--- a/src/client/components/FileUpload.js
+++ b/src/client/components/FileUpload.js
@@ -13,6 +13,7 @@ const DEFAULT_UPLOAD_TEXT =
 const FileUpload = ({
   onUpload,
   onError,
+  disabled = false,
   accept = [],
   uploadText = DEFAULT_UPLOAD_TEXT,
 }) => {
@@ -42,12 +43,20 @@ const FileUpload = ({
   );
 
   return (
-    <DropZone accept={accept} multiple={false} onDrop={onDrop}>
+    <DropZone
+      accept={accept}
+      disabled={disabled}
+      multiple={false}
+      onDrop={onDrop}
+    >
       {({ getRootProps, getInputProps, isDragActive }) => (
         <div {...getRootProps()}>
           <input {...getInputProps()} />
 
-          <FileUploadStyle isAlternateColor={isAlternateColor}>
+          <FileUploadStyle
+            disabled={disabled}
+            isAlternateColor={isAlternateColor}
+          >
             {isDragActive ? <p>Drop your file here</p> : <p>{uploadText}</p>}
           </FileUploadStyle>
         </div>
@@ -58,6 +67,7 @@ const FileUpload = ({
 
 FileUpload.propTypes = {
   accept: PropTypes.arrayOf(PropTypes.string),
+  disabled: PropTypes.bool,
   onError: PropTypes.func.isRequired,
   onUpload: PropTypes.func.isRequired,
   uploadText: PropTypes.string,
@@ -83,6 +93,8 @@ export const FileUploadStyle = styled.div`
   background-color: ${styles.colors.violet};
 
   text-overflow: ellipsis;
+
+  opacity: ${(props) => (props.disabled ? 0.2 : 1)};
 
   text-align: center;
 `;

--- a/src/client/components/Finder.js
+++ b/src/client/components/Finder.js
@@ -116,7 +116,7 @@ const Finder = ({
 
       <InputFieldStyle
         autoComplete="off"
-        isDisabled={isDisabled}
+        disabled={isDisabled}
         label={label}
         name={name}
         placeholder={placeholder}

--- a/src/client/components/FormAnswers.js
+++ b/src/client/components/FormAnswers.js
@@ -6,9 +6,9 @@ import InputFinderField from '~/client/components/InputFinderField';
 import InputHiddenField from '~/client/components/InputHiddenField';
 import translate from '~/common/services/i18n';
 
-const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
+const FormAnswers = ({ question, festivalId, isDisabled }) => {
   const schema = {};
-  if (!isArtworkAnswer) {
+  if (question.type === 'festival') {
     schema.artworkId = Joi.number()
       .required()
       .error(new Error(translate('validations.artworkRequired')));
@@ -19,7 +19,8 @@ const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
   }
 
   const filter = (item) => {
-    const filterParam = !isArtworkAnswer ? 'artworkId' : 'propertyId';
+    const filterParam =
+      question.type === 'festival' ? 'artworkId' : 'propertyId';
     const answerIds = question.answers.map((answer) => answer[filterParam]);
     const filtered = item.festivals.filter((festival) => {
       return festival.id === festivalId && !answerIds.includes(item.id);
@@ -35,7 +36,7 @@ const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
         value={{ value: question.id }}
       />
 
-      {!isArtworkAnswer ? (
+      {question.type === 'festival' ? (
         <InputFinderField
           clientSideFilter={filter}
           isDisabled={isDisabled}
@@ -63,7 +64,6 @@ const FormAnswers = ({ question, festivalId, isArtworkAnswer, isDisabled }) => {
 
 FormAnswers.propTypes = {
   festivalId: PropTypes.number,
-  isArtworkAnswer: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool,
   question: PropTypes.object.isRequired,
 };

--- a/src/client/components/FormAnswers.js
+++ b/src/client/components/FormAnswers.js
@@ -42,7 +42,7 @@ const FormAnswers = ({ question, festivalId, isDisabled }) => {
       {question.type === 'festival' ? (
         <InputFinderField
           clientSideFilter={filter}
-          isDisabled={isDisabled}
+          disabled={isDisabled}
           label={translate('AdminAnswersNew.fieldArtwork')}
           name="artworkId"
           placeholder={translate('AdminAnswersNew.fieldArtworkPlaceholder')}

--- a/src/client/components/FormAnswers.js
+++ b/src/client/components/FormAnswers.js
@@ -22,10 +22,13 @@ const FormAnswers = ({ question, festivalId, isDisabled }) => {
     const filterParam =
       question.type === 'festival' ? 'artworkId' : 'propertyId';
     const answerIds = question.answers.map((answer) => answer[filterParam]);
-    const filtered = item.festivals.filter((festival) => {
-      return festival.id === festivalId && !answerIds.includes(item.id);
-    });
-    return filtered.length >= 1;
+
+    if (filterParam === 'artworkId') {
+      const filtered = item.festivals.filter((festival) => {
+        return festival.id === festivalId && !answerIds.includes(item.id);
+      });
+      return filtered.length >= 1;
+    } else return !answerIds.includes(item.id);
   };
 
   return (
@@ -49,6 +52,7 @@ const FormAnswers = ({ question, festivalId, isDisabled }) => {
         />
       ) : (
         <InputFinderField
+          clientSideFilter={filter}
           isDisabled={isDisabled}
           label={translate('AdminAnswersNew.fieldProperty')}
           name="propertyId"

--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -5,6 +5,7 @@ import React, { Fragment } from 'react';
 import InputArtworksField from '~/client/components/InputArtworksField';
 import InputCheckboxField from '~/client/components/InputCheckboxField';
 import InputField from '~/client/components/InputField';
+import InputHiddenField from '~/client/components/InputHiddenField';
 import InputStickerField from '~/client/components/InputStickerField';
 import InputTextareaField from '~/client/components/InputTextareaField';
 import InputUploadField from '~/client/components/InputUploadField';
@@ -26,6 +27,10 @@ const FormFestivals = () => {
     subtitle: Joi.string().max(255).required(),
     title: Joi.string().max(128).required(),
     url: Joi.string().uri().allow(''),
+    question: {
+      title: Joi.string().max(128).required(),
+      type: Joi.valid('festival').required(),
+    },
   };
 
   return (
@@ -55,6 +60,21 @@ const FormFestivals = () => {
         label={translate('FormFestivals.fieldDescription')}
         name="description"
         validate={schema.description}
+      />
+
+      <InputField
+        label={translate('FormFestivals.fieldQuestion')}
+        name="question.title"
+        type="text"
+        validate={schema.question.title}
+      />
+
+      <InputHiddenField
+        label={translate('FormFestivals.fieldQuestion')}
+        name="question.type"
+        type="text"
+        value={{ value: 'festival' }}
+        validate={schema.question.type}
       />
 
       <InputCheckboxField

--- a/src/client/components/FormQuestions.js
+++ b/src/client/components/FormQuestions.js
@@ -41,7 +41,7 @@ const FormQuestions = ({ isFinderDisabled, festivalId }) => {
       />
 
       <InputFinderField
-        isDisabled={isFinderDisabled}
+        disabled={isFinderDisabled}
         label={translate('FormQuestions.fieldFestival')}
         name="festivalId"
         placeholder={translate('FormQuestions.fieldFestivalPlaceholder')}
@@ -52,7 +52,7 @@ const FormQuestions = ({ isFinderDisabled, festivalId }) => {
 
       <InputFinderField
         clientSideFilter={filter}
-        isDisabled={isFinderDisabled || !hasFestival}
+        disabled={isFinderDisabled || !hasFestival}
         label={translate('FormQuestions.fieldArtwork')}
         name="artworkId"
         placeholder={translate('FormQuestions.fieldArtworkPlaceholder')}

--- a/src/client/components/FormScheduleEmail.js
+++ b/src/client/components/FormScheduleEmail.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
 
 import InputTextareaField from '~/client/components/InputTextareaField';
 import translate from '~/common/services/i18n';
@@ -13,10 +14,11 @@ export const schema = {
     .required(),
 };
 
-const FormScheduleEmail = () => {
+const FormScheduleEmail = ({ disabled = false }) => {
   return (
     <Fragment>
       <InputTextareaField
+        disabled={disabled}
         label={translate('FormScheduleEmail.fieldRecipients')}
         name="recipients"
         rows={15}
@@ -24,6 +26,10 @@ const FormScheduleEmail = () => {
       />
     </Fragment>
   );
+};
+
+FormScheduleEmail.propTypes = {
+  disabled: PropTypes.bool,
 };
 
 export default FormScheduleEmail;

--- a/src/client/components/FormVoteweights.js
+++ b/src/client/components/FormVoteweights.js
@@ -10,7 +10,13 @@ import { web3Validators } from '~/common/helpers/validate';
 import { VOTEWEIGHT_TYPES } from '~/common/helpers/validate';
 import InputFinderField from '~/client/components/InputFinderField';
 
-const FormVoteweights = ({ festival, type, onChange }) => {
+const FormVoteweights = ({
+  festival,
+  isDisabled = false,
+  readOnly = false,
+  type,
+  onChange,
+}) => {
   const schema = {
     festivalId: Joi.number().integer().required(),
     multiplier: Joi.number().min(0.01).required(),
@@ -65,21 +71,26 @@ const FormVoteweights = ({ festival, type, onChange }) => {
       />
 
       <InputField
+        isDisabled={isDisabled}
         label={translate('FormVoteweights.fieldName')}
         name="name"
+        readOnly={readOnly}
         type="text"
         validate={schema.name}
       />
 
       <InputField
+        isDisabled={isDisabled}
         label={translate('FormVoteweights.fieldMultiplier')}
         name="multiplier"
         placeholder="eg. 1.00"
+        readOnly={readOnly}
         type="text"
         validate={schema.multiplier}
       />
 
       <InputSelectField
+        disabled={isDisabled}
         label={translate('FormVoteweights.fieldType')}
         name="type"
         validate={schema.type}
@@ -99,24 +110,30 @@ const FormVoteweights = ({ festival, type, onChange }) => {
         <Fragment>
           <InputField
             allowNull={true}
+            isDisabled={isDisabled}
             label={translate('FormVoteweights.fieldLatitude')}
             name="latitude"
+            readOnly={readOnly}
             type="text"
             validate={schema.latitude}
           />
 
           <InputField
             allowNull={true}
+            isDisabled={isDisabled}
             label={translate('FormVoteweights.fieldLongitude')}
             name="longitude"
+            readOnly={readOnly}
             type="text"
             validate={schema.longitude}
           />
 
           <InputField
             allowNull={true}
+            isDisabled={isDisabled}
             label={translate('FormVoteweights.fieldRadius')}
             name="radius"
+            readOnly={readOnly}
             type="text"
             validate={schema.radius}
           />
@@ -126,8 +143,10 @@ const FormVoteweights = ({ festival, type, onChange }) => {
       {type === 'hotspot' ? (
         <InputField
           allowNull={true}
+          isDisabled={isDisabled}
           label={translate('FormVoteweights.fieldHotspot')}
           name="hotspot"
+          readOnly={readOnly}
           type="text"
           validate={schema.hotspot}
         />
@@ -136,12 +155,14 @@ const FormVoteweights = ({ festival, type, onChange }) => {
       {type === 'organisation' ? (
         <InputFinderField
           clientSideFilter={filter}
+          isDisabled={isDisabled}
           label={translate('FormVoteweights.fieldOrganisation')}
           name="organisationId"
           placeholder={translate(
             'FormVoteweights.fieldOrganisationPlaceholder',
           )}
           queryPath={['organisations']}
+          readOnly={readOnly}
           searchParam={'name'}
           selectParam={'id'}
           validate={schema.organisationId}
@@ -153,7 +174,9 @@ const FormVoteweights = ({ festival, type, onChange }) => {
 
 FormVoteweights.propTypes = {
   festival: PropTypes.object.isRequired,
+  isDisabled: PropTypes.bool,
   onChange: PropTypes.func,
+  readOnly: PropTypes.bool,
   type: PropTypes.string,
 };
 

--- a/src/client/components/InitializeAnswer.js
+++ b/src/client/components/InitializeAnswer.js
@@ -1,0 +1,126 @@
+import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import {
+  TX_DEACTIVATE_ANSWER,
+  TX_INITIALIZE_ANSWER,
+  deactivateAnswer,
+  initializeAnswer,
+  isAnswerDeactivated,
+  isAnswerInitialized,
+} from '~/common/services/contracts/answers';
+import { addPendingTransaction } from '~/client/store/ethereum/actions';
+import {
+  usePendingTransaction,
+  useOwnerAddress,
+} from '~/client/hooks/ethereum';
+
+const InitializeAnswer = ({
+  questionChainId,
+  answerChainId,
+  children,
+  handleDeactivate = () => {},
+  handleInitialize = () => {},
+}) => {
+  const dispatch = useDispatch();
+  const owner = useOwnerAddress();
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [isDeactivated, setIsDeactivated] = useState(false);
+
+  const initializeTx = usePendingTransaction({
+    txMethod: TX_INITIALIZE_ANSWER,
+    params: { answerChainId },
+  });
+  const deactivateTx = usePendingTransaction({
+    txMethod: TX_DEACTIVATE_ANSWER,
+    params: { answerChainId },
+  });
+
+  useEffect(() => {
+    const getInitializedStatus = async () => {
+      if (questionChainId !== '') {
+        const state = await isAnswerInitialized(questionChainId, answerChainId);
+        setIsInitialized(state);
+        handleInitialize(state);
+      }
+    };
+
+    getInitializedStatus();
+  }, [
+    questionChainId,
+    answerChainId,
+    initializeTx.isPending,
+    handleInitialize,
+  ]);
+
+  useEffect(() => {
+    const getDeactivatedStatus = async () => {
+      const state = await isAnswerDeactivated(questionChainId, answerChainId);
+      setIsDeactivated(state);
+      handleDeactivate(state);
+    };
+
+    getDeactivatedStatus();
+  }, [
+    questionChainId,
+    answerChainId,
+    deactivateTx.isPending,
+    handleDeactivate,
+  ]);
+
+  const onInitialize = async (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const { txHash, txMethod } = await initializeAnswer(
+      owner,
+      questionChainId,
+      answerChainId,
+    );
+
+    dispatch(
+      addPendingTransaction({
+        txHash,
+        txMethod,
+        params: { answerChainId },
+      }),
+    );
+  };
+
+  const onDeactivate = async (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const { txHash, txMethod } = await deactivateAnswer(
+      owner,
+      questionChainId,
+      answerChainId,
+    );
+
+    dispatch(
+      addPendingTransaction({
+        txHash,
+        txMethod,
+        params: { answerChainId },
+      }),
+    );
+  };
+
+  return children({
+    isInitialized,
+    isDeactivated,
+    onInitialize,
+    onDeactivate,
+  });
+};
+
+InitializeAnswer.propTypes = {
+  answerChainId: PropTypes.string.isRequired,
+  children: PropTypes.func.isRequired,
+  handleDeactivate: PropTypes.func,
+  handleInitialize: PropTypes.func,
+  questionChainId: PropTypes.string.isRequired,
+};
+
+export default InitializeAnswer;

--- a/src/client/components/InputField.js
+++ b/src/client/components/InputField.js
@@ -34,7 +34,7 @@ export const InputFieldStyle = styled.input`
 
   background-color: transparent;
 
-  opacity: ${(props) => (props.isDisabled ? 0.2 : 1)};
+  opacity: ${(props) => (props.disabled ? 0.2 : 1)};
 `;
 
 InputField.propTypes = {

--- a/src/client/components/InputFinderField.js
+++ b/src/client/components/InputFinderField.js
@@ -11,6 +11,7 @@ const InputFinderField = ({
   isDisabled = false,
   label,
   name,
+  onChangeCallback = null,
   placeholder,
   queryPath,
   searchParam,
@@ -27,6 +28,10 @@ const InputFinderField = ({
       setValue(item[selectParam]);
     } else {
       setValue(null);
+    }
+
+    if (onChangeCallback) {
+      onChangeCallback(item);
     }
 
     setMeta({
@@ -59,6 +64,7 @@ InputFinderField.propTypes = {
   isDisabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  onChangeCallback: PropTypes.func,
   placeholder: PropTypes.string.isRequired,
   queryPath: PropTypes.arrayOf(PropTypes.string).isRequired,
   searchParam: PropTypes.string.isRequired,

--- a/src/client/components/InputTextareaField.js
+++ b/src/client/components/InputTextareaField.js
@@ -36,6 +36,8 @@ export const InputTextareaFieldStyle = styled.textarea`
   color: ${styles.colors.violet};
 
   background-color: transparent;
+
+  opacity: ${(props) => (props.disabled ? 0.2 : 1)};
 `;
 
 InputTextareaField.propTypes = {

--- a/src/client/components/SnuggleRain.js
+++ b/src/client/components/SnuggleRain.js
@@ -69,7 +69,7 @@ function resetParticle(particle) {
 
 function updateParticles(frameIndex, dimensions) {
   particles.forEach((particle) => {
-    if (!particle.isActive && isRequestingSnugglepunk && snuggleness > 0) {
+    if (!particle.isActive && isRequestingSnugglepunk && snuggleness > 0.5) {
       // Spawn a snugglepunk!
       particle.x =
         (dimensions.width / particles.length) *

--- a/src/client/components/SnuggleRain.js
+++ b/src/client/components/SnuggleRain.js
@@ -69,7 +69,7 @@ function resetParticle(particle) {
 
 function updateParticles(frameIndex, dimensions) {
   particles.forEach((particle) => {
-    if (!particle.isActive && isRequestingSnugglepunk) {
+    if (!particle.isActive && isRequestingSnugglepunk && snuggleness > 0) {
       // Spawn a snugglepunk!
       particle.x =
         (dimensions.width / particles.length) *

--- a/src/client/components/Table.js
+++ b/src/client/components/Table.js
@@ -6,6 +6,7 @@ import { useLocation, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
 import ButtonOutline from '~/client/components/ButtonOutline';
+import InitializeAnswer from '~/client/components/InitializeAnswer';
 import styles from '~/client/styles/variables';
 import translate from '~/common/services/i18n';
 import { getCached } from '~/client/services/cache';
@@ -24,6 +25,7 @@ export const PARAM_PAGE_INDEX = 'page';
 export const ACTION_DESTROY = Symbol('select-destroy');
 export const ACTION_EDIT = Symbol('select-edit');
 export const ACTION_SELECT = Symbol('select-action');
+export const ACTION_ANSWER_INITIALIZE = Symbol('answer-initialize-action');
 
 const DEFAULT_HEADERS = [
   {
@@ -320,7 +322,11 @@ export const TableBody = ({
             <TableBodyItems columns={columns} values={item} />
             <td>
               {actions.length !== 0 ? (
-                <TableActions actions={actions} onSelect={onSelectAction} />
+                <TableActions
+                  actions={actions}
+                  item={item}
+                  onSelect={onSelectAction}
+                />
               ) : null}
             </td>
           </tr>
@@ -360,12 +366,17 @@ export const TableBodyItems = ({ columns, values }) => {
   });
 };
 
-export const TableActions = ({ actions, onSelect }) => {
+export const TableActions = ({ actions, onSelect, item }) => {
   return actions.map((action, index) => {
     const onSelectAction = (event) => {
       event.stopPropagation();
       onSelect(action.key);
     };
+
+    if (action.key === ACTION_ANSWER_INITIALIZE)
+      return (
+        <TableActionInitializeAnswer item={item} key={`action-${index}`} />
+      );
 
     return (
       <ButtonOutline
@@ -419,6 +430,35 @@ export const TableFooter = ({
   );
 };
 
+export const TableActionInitializeAnswer = ({ item }) => {
+  return (
+    <InitializeAnswer
+      answerChainId={item.chainId}
+      questionChainId={item.question.chainId}
+    >
+      {({ isInitialized, isDeactivated, onInitialize, onDeactivate }) => {
+        return (
+          <>
+            {isDeactivated ? (
+              <DeactivatedStyle>
+                {translate('Table.answerAlreadyDeactivated')}
+              </DeactivatedStyle>
+            ) : isInitialized ? (
+              <ButtonOutline isDanger={true} onClick={onDeactivate}>
+                {translate('Table.buttonDeactivateAnswer')}
+              </ButtonOutline>
+            ) : (
+              <ButtonOutline onClick={onInitialize}>
+                {translate('Table.buttonInitializeAnswer')}
+              </ButtonOutline>
+            )}
+          </>
+        );
+      }}
+    </InitializeAnswer>
+  );
+};
+
 export const TableStyle = styled.table`
   width: 100%;
 
@@ -460,6 +500,12 @@ const TableFooterStyle = styled.tfoot`
   tr {
     margin-top: 1rem;
   }
+`;
+
+const DeactivatedStyle = styled.span`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-right: 0.5rem;
 `;
 
 const PropTypesAction = PropTypes.shape({
@@ -530,6 +576,10 @@ TableFooter.propTypes = {
   onSelect: PropTypes.func.isRequired,
   pageIndex: PropTypes.number.isRequired,
   pagesTotal: PropTypes.number.isRequired,
+};
+
+TableActionInitializeAnswer.propTypes = {
+  item: PropTypes.object.isRequired,
 };
 
 export default Table;

--- a/src/client/components/VoteweightsContainer.js
+++ b/src/client/components/VoteweightsContainer.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import Table, { ACTION_DESTROY } from '~/client/components/Table';
+import Table, { ACTION_EDIT } from '~/client/components/Table';
 import translate from '~/common/services/i18n';
-import { destroyRequest } from '~/client/store/api/actions';
+import { getRequest } from '~/client/store/api/actions';
 import { HeadingSecondaryStyle } from '~/client/styles/typography';
 import styles from '~/client/styles/variables';
 import swirl from '~/client/assets/images/swirl.svg';
@@ -16,9 +17,8 @@ const table = {
   path: ['voteweights'],
   actions: [
     {
-      label: translate('VoteweightsTable.buttonDelete'),
-      isDangerous: true,
-      key: ACTION_DESTROY,
+      label: translate('default.tableActionView'),
+      key: ACTION_EDIT,
     },
   ],
   columns: [
@@ -37,15 +37,14 @@ const table = {
 
 const VoteweightsContainer = ({ festivalId }) => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const { slug } = useParams();
 
   const onSelect = ({ item }) => {
-    if (!window.confirm(translate('default.areYouSure'))) {
-      return;
-    }
+    history.push(`/admin/festivals/${slug}/voteweights/${item.id}`);
 
     dispatch(
-      destroyRequest({
+      getRequest({
         path: ['voteweights', item.id],
       }),
     );

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -31,6 +31,7 @@ import AdminUsers from '~/client/views/AdminUsers';
 import AdminUsersEdit from '~/client/views/AdminUsersEdit';
 import AdminUsersNew from '~/client/views/AdminUsersNew';
 import AdminVoteweightsNew from '~/client/views/AdminVoteweightsNew';
+import AdminVoteweightsView from '~/client/views/AdminVoteweightsView';
 import Artworks from '~/client/views/Artworks';
 import ArtworksProfile from '~/client/views/ArtworksProfile';
 import Booth from '~/client/views/Booth';
@@ -172,6 +173,11 @@ const Routes = () => (
       component={AdminVoteweightsNew}
       exact
       path="/admin/festivals/:slug/voteweights/new"
+    />
+    <AuthenticatedRoute
+      component={AdminVoteweightsView}
+      exact
+      path="/admin/festivals/:slug/voteweights/:voteweightId"
     />
     <AuthenticatedRoute
       component={AdminQuestions}

--- a/src/client/views/AdminAnswersEdit.js
+++ b/src/client/views/AdminAnswersEdit.js
@@ -33,7 +33,6 @@ const AdminAnswersEdit = () => {
             <Fragment>
               <FormAnswers
                 festivalId={resource.festivalId}
-                isArtworkAnswer={!!resource.artwork}
                 isDisabled
                 question={resource.question}
               />

--- a/src/client/views/AdminAnswersEdit.js
+++ b/src/client/views/AdminAnswersEdit.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { Fragment, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import ButtonIcon from '~/client/components/ButtonIcon';
@@ -7,15 +7,12 @@ import FooterAdmin from '~/client/components/FooterAdmin';
 import FormAnswers from '~/client/components/FormAnswers';
 import HeaderAdmin from '~/client/components/HeaderAdmin';
 import ViewAdmin from '~/client/components/ViewAdmin';
-import apiRequest from '~/client/services/api';
 import translate from '~/common/services/i18n';
 import { useEditForm } from '~/client/hooks/forms';
 import DangerZone from '~/client/components/DangerZone';
 
 const AdminAnswersEdit = () => {
   const { questionId, answerId } = useParams();
-  const [isLoading, setIsLoading] = useState(true);
-  const [question, setQuestion] = useState({});
   const [isDeactivated, setIsDeactivated] = useState(false);
 
   const returnUrl = `/admin/questions/${questionId}/edit`;
@@ -26,30 +23,19 @@ const AdminAnswersEdit = () => {
     returnUrl,
   });
 
-  useEffect(() => {
-    const getQuestion = async () => {
-      const response = await apiRequest({
-        path: ['questions', questionId],
-      });
-      setQuestion(response);
-      setIsLoading(false);
-    };
-    getQuestion();
-  }, [setQuestion, setIsLoading, questionId]);
-
   return (
     <Fragment>
       <HeaderAdmin>{translate('AdminAnswersEdit.title')}</HeaderAdmin>
 
       <ViewAdmin>
         <Form>
-          {!isLoading && !isResourceLoading && resource.chainId && (
+          {!isResourceLoading && resource.chainId && (
             <Fragment>
               <FormAnswers
                 festivalId={resource.festivalId}
                 isArtworkAnswer={!!resource.artwork}
                 isDisabled
-                question={question}
+                question={resource.question}
               />
 
               {isDeactivated ? (
@@ -60,9 +46,8 @@ const AdminAnswersEdit = () => {
 
               <ContractsAnswers
                 answerChainId={resource.chainId}
-                isDeactivated={isDeactivated}
-                questionChainId={question.chainId}
-                setIsDeactivated={setIsDeactivated}
+                handleDeactivate={(state) => setIsDeactivated(state)}
+                questionChainId={resource.question.chainId}
               />
             </Fragment>
           )}

--- a/src/client/views/AdminAnswersNew.js
+++ b/src/client/views/AdminAnswersNew.js
@@ -71,7 +71,6 @@ const AdminAnswersNew = () => {
             <Fragment>
               <FormAnswers
                 festivalId={question.festivalId}
-                isArtworkAnswer={!!question.artworkId}
                 question={question}
               />
 

--- a/src/client/views/AdminEmails.js
+++ b/src/client/views/AdminEmails.js
@@ -1,5 +1,5 @@
-import React, { Fragment } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { Fragment, useState, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import Joi from 'joi';
 
@@ -9,6 +9,8 @@ import FooterAdmin from '~/client/components/FooterAdmin';
 import HeaderAdmin from '~/client/components/HeaderAdmin';
 import ViewAdmin from '~/client/components/ViewAdmin';
 import ButtonSubmit from '~/client/components/ButtonSubmit';
+import InputFinderField from '~/client/components/InputFinderField';
+import ContractsEmailSigner from '~/client/components/ContractsEmailSigner';
 import translate from '~/common/services/i18n';
 import { HelpCopyStyle, SpacingGroupStyle } from '~/client/styles/layout';
 import { ParagraphStyle, PreStyle } from '~/client/styles/typography';
@@ -21,13 +23,96 @@ import FormScheduleEmail, {
   schema,
 } from '~/client/components/FormScheduleEmail';
 import { useRequestForm } from '~/client/hooks/forms';
+import apiRequest from '~/client/services/api';
+import { signBooth } from '~/common/services/vote';
+import { BOOTH_ACCOUNT_NAME, resetBooth } from '~/client/store/booth/actions';
+import { getPrivateKey } from '~/client/services/wallet';
 
 const AdminEmails = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const requestId = useRequestId();
+  const booth = useSelector((state) => state.booth);
+  const [isReadyToSign, setIsReadyToSign] = useState(false);
+  const [selectedFestival, setSelectedFestival] = useState(null);
+  const [festivalQuestionId, setFestivalQuestionId] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [privateKey, setPrivateKey] = useState(false);
+
+  const organisationSchema = Joi.number()
+    .allow(null)
+    .error(new Error(translate('validations.artworkRequired')));
 
   const returnUrl = '/admin';
+
+  useEffect(() => {
+    setIsReadyToSign(booth.address && booth.isInitialized && !booth.isDisabled);
+  }, [booth, setIsReadyToSign]);
+
+  useEffect(() => {
+    if (isReadyToSign) {
+      setIsLoading(true);
+      const resolve = async () => {
+        try {
+          if (!booth.festivalChainId) return;
+          const resources = await apiRequest({
+            path: ['festivals', booth.festivalChainId, 'questions'],
+          });
+          setSelectedFestival(resources);
+          setIsLoading(false);
+          setPrivateKey(getPrivateKey(BOOTH_ACCOUNT_NAME));
+        } catch (error) {
+          dispatch(
+            notify({
+              text: translate('AdminEmails.errorUnknownFestivalChainId'),
+              type: NotificationsTypes.ERROR,
+            }),
+          );
+        }
+      };
+
+      resolve();
+    }
+  }, [
+    booth,
+    isReadyToSign,
+    setSelectedFestival,
+    setIsLoading,
+    dispatch,
+    setPrivateKey,
+  ]);
+
+  const festivalAnswerIds = useMemo(() => {
+    if (!selectedFestival) return [];
+
+    if (!selectedFestival.questions) {
+      return [];
+    }
+
+    try {
+      const result = selectedFestival.questions.reduce((acc, question) => {
+        if (question.artworkId === null) {
+          setFestivalQuestionId(question.id);
+          question.answers.forEach((answer) => {
+            acc.push(answer.id);
+          });
+        }
+
+        return acc;
+      }, []);
+
+      return result;
+    } catch {
+      dispatch(
+        notify({
+          text: translate('AdminEmails.errorInvalidData'),
+          type: NotificationsTypes.ERROR,
+        }),
+      );
+
+      return [];
+    }
+  }, [dispatch, selectedFestival]);
 
   const textareaToRecipients = (value) =>
     [
@@ -55,13 +140,38 @@ const AdminEmails = () => {
     requestId,
     schema,
     onSubmit: (values) => {
+      if (festivalAnswerIds.length == 0) {
+        return dispatch(
+          notify({
+            text: translate('AdminEmails.errorInvalidData'),
+            type: NotificationsTypes.ERROR,
+          }),
+        );
+      }
+
       dispatch(
         putRequest({
           id: requestId,
           path: ['tasks'],
           body: {
             kind: 'vote_invitations',
-            data: textareaToRecipients(values.recipients).map((to) => ({ to })),
+            data: textareaToRecipients(values.recipients).map((to, index) => {
+              const nonce = index;
+              const boothSignature = signBooth({
+                festivalAnswerIds,
+                privateKey,
+                nonce,
+              });
+              return {
+                to,
+                booth: booth.address,
+                boothSignature,
+                festivalAnswerIds,
+                festivalQuestionId,
+                nonce,
+                organisationId: values.organisationId,
+              };
+            }),
           },
         }),
       );
@@ -75,6 +185,7 @@ const AdminEmails = () => {
       );
     },
     onSuccess: () => {
+      dispatch(resetBooth());
       dispatch(
         notify({
           text: translate('AdminEmails.notificationSuccess', {
@@ -116,22 +227,37 @@ const AdminEmails = () => {
       <HeaderAdmin>{translate('AdminEmails.title')}</HeaderAdmin>
 
       <ViewAdmin>
+        <ContractsEmailSigner
+          booth={booth}
+          isReadyToSign={isReadyToSign}
+          setFestival={setSelectedFestival}
+        />
         <HelpCopyStyle>
           <ParagraphStyle>{translate('AdminEmails.copy')}</ParagraphStyle>
           <ParagraphStyle>{translate('AdminEmails.copyUpload')}</ParagraphStyle>
           <PreStyle>{translate('AdminEmails.example')}</PreStyle>
         </HelpCopyStyle>
-
         <Form>
-          <FormScheduleEmail />
+          <InputFinderField
+            isDisabled={!isReadyToSign}
+            label={translate('AdminEmails.fieldOrganisationId')}
+            name="organisationId"
+            placeholder={translate('AdminEmails.fieldOrganisationPlaceholder')}
+            queryPath={['organisations']}
+            searchParam={'name'}
+            selectParam={'id'}
+            validate={organisationSchema}
+          />
+          <FormScheduleEmail disabled={!isReadyToSign} />
 
           <FileUpload
             accept={['text/plain', 'text/csv', 'text/x-csv']}
+            disabled={!isReadyToSign}
             uploadText={translate('AdminEmails.fileUpload')}
             onError={handleFileUploadError}
             onUpload={handleFileUpload}
           />
-          <ButtonSubmit disabled={!isValid} />
+          <ButtonSubmit disabled={!isValid && !isLoading} />
         </Form>
       </ViewAdmin>
 

--- a/src/client/views/AdminFestivalsNew.js
+++ b/src/client/views/AdminFestivalsNew.js
@@ -29,6 +29,7 @@ const AdminFestivalsNew = () => {
       'subtitle',
       'title',
       'url',
+      'question',
     ],
     resourcePath: ['festivals'],
     returnUrl,

--- a/src/client/views/AdminVoteweightsView.js
+++ b/src/client/views/AdminVoteweightsView.js
@@ -1,0 +1,118 @@
+import React, { Fragment, useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+
+import ButtonIcon from '~/client/components/ButtonIcon';
+import DangerZone from '~/client/components/DangerZone';
+import FooterAdmin from '~/client/components/FooterAdmin';
+import FormVoteweights from '~/client/components/FormVoteweights';
+import HeaderAdmin from '~/client/components/HeaderAdmin';
+import ViewAdmin from '~/client/components/ViewAdmin';
+import apiRequest from '~/client/services/api';
+import notify, {
+  NotificationsTypes,
+} from '~/client/store/notifications/actions';
+import translate from '~/common/services/i18n';
+import { useEditForm } from '~/client/hooks/forms';
+
+const AdminVoteweightsView = () => {
+  const dispatch = useDispatch();
+  const { slug, voteweightId } = useParams();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [festival, setFestival] = useState({});
+  const [type, setType] = useState('location');
+
+  const returnUrl = `/admin/festivals/${slug}/edit`;
+
+  useEffect(() => {
+    const getFestival = async () => {
+      const response = await apiRequest({
+        path: ['festivals', slug],
+      });
+
+      setFestival(response);
+      setIsLoading(false);
+    };
+
+    getFestival();
+  }, [setFestival, setIsLoading, slug]);
+
+  const { ButtonDelete, Form } = useEditForm({
+    fields: [
+      'festivalId',
+      'name',
+      'multiplier',
+      'type',
+      'latitude',
+      'longitude',
+      'radius',
+      'hotspot',
+      'organisationId',
+    ],
+    resourcePath: ['voteweights', voteweightId],
+    returnUrl,
+    onNotFound: () => {
+      dispatch(
+        notify({
+          text: translate('AdminVoteweightsView.errorNotFound'),
+        }),
+      );
+    },
+    onDeleteSuccess: ({ name }) => {
+      dispatch(
+        notify({
+          text: translate('AdminVoteweightsView.notificationDestroySuccess', {
+            name,
+          }),
+        }),
+      );
+    },
+    onError: () => {
+      dispatch(
+        notify({
+          text: translate('default.errorMessage'),
+          type: NotificationsTypes.ERROR,
+        }),
+      );
+    },
+  });
+
+  const onChange = (event) => {
+    event.preventDefault();
+    setType(event.target.value);
+  };
+
+  return (
+    <Fragment>
+      <HeaderAdmin>{translate('AdminVoteweightsView.title')}</HeaderAdmin>
+
+      <ViewAdmin>
+        <Form>
+          {!isLoading && festival ? (
+            <Fragment>
+              <FormVoteweights
+                festival={festival}
+                isDisabled={true}
+                readOnly={true}
+                type={type}
+                onChange={onChange}
+              />
+              <DangerZone>
+                <ButtonDelete />
+              </DangerZone>
+            </Fragment>
+          ) : null}
+        </Form>
+      </ViewAdmin>
+
+      <FooterAdmin>
+        <ButtonIcon isIconFlipped to={returnUrl}>
+          {translate('AdminVoteweightsView.buttonBackToFestival')}
+        </ButtonIcon>
+      </FooterAdmin>
+    </Fragment>
+  );
+};
+
+export default AdminVoteweightsView;

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -126,7 +126,7 @@ const components = {
     fieldMultiplier: 'Multiplier:',
     fieldLatitude: 'Latitude:',
     fieldLongitude: 'Longitude:',
-    fieldRadius: 'Radius in metres:',
+    fieldRadius: 'Radius in km:',
     fieldHotspot: 'Hotspot Address:',
     fieldOrganisation: 'Organisation:',
     fieldOrganisationPlaceholder: 'Search for an organisation to add',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -188,6 +188,9 @@ const components = {
     bodyLoading: 'Loading ...',
     columnCreatedAt: 'Created at',
     columnUpdatedAt: 'Updated at',
+    answerAlreadyDeactivated: 'Deactivated',
+    buttonDeactivateAnswer: 'Deactivate',
+    buttonInitializeAnswer: 'Initialize',
   },
   VoteCreditsBar: {
     voteCredits: 'Vote Credits',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -415,6 +415,12 @@ ccc@example.org`,
     notificationSuccess: 'You created a new vote weight.',
     title: 'Create new vote weight',
   },
+  AdminVoteweightsView: {
+    errorNotFound: 'This voteweight does not exist.',
+    notificationDestroySuccess: 'You deleted the voteweight {name}.',
+    title: 'View vote weight',
+    buttonBackToFestival: 'Back to festival.',
+  },
   Artworks: {
     buttonBackToFestival: 'Back to festival',
   },
@@ -460,6 +466,7 @@ export default {
   default: {
     areYouSure: 'Are you sure you really want to do this?',
     buttonDestroy: 'Delete',
+    buttonView: 'View',
     buttonLoadMore: 'Load more',
     buttonReturnToDashboard: 'Return to dashboard',
     buttonReturnToOverview: 'Return to overview',
@@ -470,6 +477,7 @@ export default {
     legendVotes: 'Votes',
     tableActionDestroy: 'Delete',
     tableActionEdit: 'Edit',
+    tableActionView: 'View',
   },
   validations: {
     artistRequired: 'is required',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -36,6 +36,18 @@ const components = {
     errorNotInitialized: 'Festival must be initialized',
     title: 'Add New Voting Booth',
   },
+  ContractsEmailSigner: {
+    addressLabel: 'Booth address:',
+    buttonAddNewBooth: 'Create New Voting Booth',
+    buttonBurnBooth: 'Delete Booth',
+    buttonInitializeBooth: 'Initialize',
+    fieldBoothAddress: 'Booth Address:',
+    fieldFestivalChainId: 'Festival:',
+    fieldFestivalPlaceholder: 'Choose a festival',
+    errorNotInitialized: 'Festival must be initialized',
+    startTitle: 'Add New Voting Booth',
+    finishTitle: 'Booth is ready',
+  },
   ContractsFestivals: {
     bodyAlreadyDeactivated: 'This festival is deactivated',
     bodyFestivalStartTime: 'From date:',
@@ -222,7 +234,7 @@ const components = {
     buttonReset: 'Reset',
     buttonVoteOnBooth: 'Vote here',
     errorInvalidData: 'Inconsistent data to create vote',
-    errorUnknownFestivalChainId: 'No know festival connected to this booth',
+    errorUnknownFestivalChainId: 'No known festival connected to this booth',
     notificationAddedArtwork: 'Activated {title}',
     titleAdmin: 'Admin',
     titleStartVote: 'Start vote session',
@@ -320,16 +332,20 @@ const views = {
     title: 'Questions',
   },
   AdminEmails: {
-    copy: `You can add recipients in the text box below, one email per line.`,
+    copy: `After setting up a booth, you can add recipients in the text box below, one email per line.`,
     copyUpload: `Or, upload a text file containing email addresses, again one email per line. Optionally, you can use the first line of the file as a header. For example this is a valid file to upload:`,
     example: `Emails
 aaa@example.org
 bbb@example.org
 ccc@example.org`,
     buttonSendEmails: 'Schedule Emails',
+    fieldOrganisationPlaceholder: 'Organisation',
+    fieldOrganisationId: 'Search for an organisation',
     title: 'Schedule Email',
     notificationSuccess: 'Scheduled {amount} emails.',
     fileUpload: 'Drag a file with recipients here or click to select.',
+    errorUnknownFestivalChainId: 'No known festival connected to this booth',
+    errorInvalidData: 'Invalid data: festival question and answers must exist',
   },
   AdminQuestionsNew: {
     title: 'Create new question',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -74,6 +74,7 @@ const components = {
     fieldSticker: 'Sticker',
     fieldSubtitle: 'Subtitle',
     fieldTitle: 'Title:',
+    fieldQuestion: 'Question:',
     fieldArtworks: 'Artworks:',
     fieldUrl: 'Website:',
   },

--- a/src/server/controllers/answers.js
+++ b/src/server/controllers/answers.js
@@ -36,7 +36,7 @@ const readOptions = {
     {
       association: AnswerBelongsToQuestion,
       destroyCascade: false,
-      fields: ['title'],
+      fields: ['title', 'type'],
       fieldsProtected: ['chainId'],
     },
   ],

--- a/src/server/controllers/answers.js
+++ b/src/server/controllers/answers.js
@@ -3,14 +3,42 @@ import baseController from '~/server/controllers';
 import {
   AnswerBelongsToArtwork,
   AnswerBelongsToProperty,
+  AnswerBelongsToQuestion,
 } from '~/server/database/associations';
 
 import { answerFields } from '~/server/database/associations';
 
 const options = {
   model: Answer,
-  fields: [...answerFields, 'artwork', 'property'],
+  fields: [...answerFields, 'artwork', 'property', 'question'],
   fieldsProtected: ['chainId'],
+};
+
+const readOptions = {
+  ...options,
+
+  include: [
+    AnswerBelongsToProperty,
+    AnswerBelongsToArtwork,
+    AnswerBelongsToQuestion,
+  ],
+  associations: [
+    {
+      association: AnswerBelongsToProperty,
+      destroyCascade: false,
+      fields: ['title'],
+    },
+    {
+      association: AnswerBelongsToArtwork,
+      destroyCascade: false,
+      fields: ['title'],
+    },
+    {
+      association: AnswerBelongsToQuestion,
+      destroyCascade: false,
+      fields: ['title', 'chainId'],
+    },
+  ],
 };
 
 function create(req, res, next) {
@@ -19,26 +47,13 @@ function create(req, res, next) {
 
 function readAll(req, res, next) {
   baseController.readAll({
-    ...options,
+    ...readOptions,
     where: req.locals && req.locals.query,
-    include: [AnswerBelongsToProperty, AnswerBelongsToArtwork],
-    associations: [
-      {
-        association: AnswerBelongsToProperty,
-        destroyCascade: false,
-        fields: ['title'],
-      },
-      {
-        association: AnswerBelongsToArtwork,
-        destroyCascade: false,
-        fields: ['title'],
-      },
-    ],
   })(req, res, next);
 }
 
 function read(req, res, next) {
-  baseController.read(options)(req, res, next);
+  baseController.read(readOptions)(req, res, next);
 }
 
 function destroy(req, res, next) {

--- a/src/server/controllers/answers.js
+++ b/src/server/controllers/answers.js
@@ -36,7 +36,8 @@ const readOptions = {
     {
       association: AnswerBelongsToQuestion,
       destroyCascade: false,
-      fields: ['title', 'chainId'],
+      fields: ['title'],
+      fieldsProtected: ['chainId'],
     },
   ],
 };

--- a/src/server/controllers/festivals.js
+++ b/src/server/controllers/festivals.js
@@ -12,6 +12,7 @@ import {
   ArtworkBelongsToManyFestivals,
   ArtworkHasManyImages,
   FestivalBelongsToManyArtworks,
+  FestivalHasOneQuestion,
   FestivalHasManyDocuments,
   FestivalHasManyImages,
   FestivalHasManyQuestions,
@@ -33,12 +34,20 @@ import { respondWithSuccess } from '~/server/helpers/respond';
 
 const options = {
   model: Festival,
-  fields: [...festivalFields, 'images', 'artworks', 'online', 'voteweights'],
+  fields: [
+    ...festivalFields,
+    'images',
+    'artworks',
+    'online',
+    'voteweights',
+    'question',
+  ],
   fieldsProtected: ['documents', 'chainId'],
   include: [
     FestivalBelongsToManyArtworks,
     FestivalHasManyDocuments,
     FestivalHasManyImages,
+    FestivalHasOneQuestion,
   ],
   associations: [
     {
@@ -63,6 +72,7 @@ const optionsRead = {
     FestivalHasManyDocuments,
     FestivalHasManyImages,
     FestivalHasManyVoteweights,
+    FestivalHasOneQuestion,
   ],
   associations: [
     {

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -77,7 +77,11 @@ export function filterResponseFields(req, data, options) {
 
 export function filterResponseFieldsAll(req, arr, options) {
   return arr.map((data) => {
-    return filterResponseFields(req, data, options);
+    const filter = options.customFilter
+      ? options.customFilter
+      : filterResponseFields;
+
+    return filter(req, data, options);
   });
 }
 

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -190,7 +190,9 @@ async function destroyAssociations(instance, associations) {
 function create(options) {
   return async (req, res, next) => {
     try {
-      const instance = await options.model.create(req.body);
+      const instance = await options.model.create(req.body, {
+        include: options.include,
+      });
 
       await handleAssociations(instance, options.associations, req.body);
 

--- a/src/server/controllers/tasks.js
+++ b/src/server/controllers/tasks.js
@@ -2,6 +2,7 @@ import httpStatus from 'http-status';
 
 import { respondWithSuccess } from '~/server/helpers/respond';
 import { voteInvitationEmail } from '~/server/tasks/sendmail';
+import Invitation from '~/server/models/Invitation';
 
 async function create(req, res) {
   const { kind, data } = req.body;
@@ -9,7 +10,10 @@ async function create(req, res) {
   switch (kind) {
     case 'vote_invitations': {
       await Promise.all(
-        data.map(({ to, ...rest }) => voteInvitationEmail(to, rest)),
+        data.map(async ({ to, ...rest }) => {
+          await Invitation.create({ email: to, ...rest });
+          return voteInvitationEmail(to, rest);
+        }),
       );
     }
   }

--- a/src/server/database/associations.js
+++ b/src/server/database/associations.js
@@ -50,7 +50,13 @@ export const imageFileFields = [
 ];
 export const organisationFields = ['description', 'name'];
 export const propertyFields = ['title'];
-export const questionFields = ['title', 'chainId', 'artworkId', 'festivalId'];
+export const questionFields = [
+  'title',
+  'chainId',
+  'artworkId',
+  'festivalId',
+  'type',
+];
 export const userFields = ['username', 'email'];
 export const voteFields = [
   'boothAddress',

--- a/src/server/database/associations.js
+++ b/src/server/database/associations.js
@@ -140,6 +140,11 @@ export const ArtistHasManyImages = Artist.hasMany(Image, {
 });
 
 // Festival
+export const FestivalHasOneQuestion = Festival.hasOne(Question, {
+  allowNull: false,
+  onDelete: 'CASCADE',
+  onUpdate: 'CASCADE',
+});
 
 export const FestivalHasManyImages = Festival.hasMany(Image, {
   ...attachableMixin,

--- a/src/server/database/migrations/20210318141145-add-invitations.js
+++ b/src/server/database/migrations/20210318141145-add-invitations.js
@@ -1,0 +1,48 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('invitations', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      booth: {
+        type: Sequelize.STRING(42),
+        allowNull: false,
+      },
+      boothSignature: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      festivalQuestionId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      festivalAnswerIds: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+      },
+      nonce: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      organisationId: {
+        type: Sequelize.INTEGER,
+      },
+    });
+  },
+  down: (queryInterface) => {
+    return queryInterface.dropTable('invitations');
+  },
+};

--- a/src/server/helpers/filters.js
+++ b/src/server/helpers/filters.js
@@ -10,6 +10,7 @@ export function locationFilter(req, data, options) {
 
   const longitude = data.dataValues.location.coordinates[0];
   const latitude = data.dataValues.location.coordinates[1];
+  const radius = data.dataValues.radius / 1000;
 
   data.set('latitude', latitude, {
     raw: true,
@@ -18,6 +19,8 @@ export function locationFilter(req, data, options) {
   data.set('longitude', longitude, {
     raw: true,
   });
+
+  data.set('radius', radius);
 
   return filterResponseFields(req, data, {
     ...options,

--- a/src/server/middlewares/locationFormatting.js
+++ b/src/server/middlewares/locationFormatting.js
@@ -5,5 +5,8 @@ export default async function locationFormatting(req, res, next) {
       coordinates: [req.body.longitude, req.body.latitude],
     };
   }
+  if (req.body && req.body.radius) {
+    req.body.radius = req.body.radius * 1000;
+  }
   next();
 }

--- a/src/server/models/invitation.js
+++ b/src/server/models/invitation.js
@@ -1,0 +1,48 @@
+import { DataTypes } from 'sequelize';
+
+import db from '~/server/database';
+
+const Invitation = db.define('invitation', {
+  id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  booth: {
+    type: DataTypes.STRING,
+    validate: {
+      isAlphanumeric: true,
+    },
+    allowNull: false,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  boothSignature: {
+    type: DataTypes.STRING,
+    unique: true,
+    allowNull: false,
+    validate: {
+      isAlphanumeric: true,
+    },
+  },
+  nonce: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  festivalQuestionId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  festivalAnswerIds: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+  },
+  organisationId: {
+    type: DataTypes.INTEGER,
+  },
+});
+
+export default Invitation;

--- a/src/server/services/redis.js
+++ b/src/server/services/redis.js
@@ -1,3 +1,15 @@
+import redis from 'redis';
+
+import logger from '~/server/helpers/logger';
+
+const client = redis.createClient();
+
+client.on('error', function (error) {
+  logger.error(error);
+});
+
+export default client;
+
 export const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
 
 export const redisOptions = {

--- a/src/server/validations/festivals.js
+++ b/src/server/validations/festivals.js
@@ -21,6 +21,14 @@ const defaultValidation = {
   url: Joi.string().uri().allow(''),
 };
 
+const createValidation = {
+  ...defaultValidation,
+  question: {
+    title: Joi.string().max(128).required(),
+    type: Joi.valid('festival').required(),
+  },
+};
+
 export default {
   getArtworks: {
     [Segments.PARAMS]: {
@@ -38,7 +46,7 @@ export default {
   },
   create: {
     [Segments.BODY]: {
-      ...defaultValidation,
+      ...createValidation,
     },
   },
   readAll: {

--- a/src/server/validations/questions.js
+++ b/src/server/validations/questions.js
@@ -7,6 +7,10 @@ const defaultValidation = {
   artworkId: Joi.number().integer().allow(null),
   festivalId: Joi.number().integer().required(),
   title: Joi.string().max(128).required(),
+};
+
+const createValidation = {
+  ...defaultValidation,
   type: Joi.alternatives()
     .conditional('artworkId', {
       is: undefined,
@@ -20,7 +24,7 @@ const defaultValidation = {
 export default {
   create: {
     [Segments.BODY]: {
-      ...defaultValidation,
+      ...createValidation,
     },
   },
   readAll: {

--- a/src/server/validations/tasks.js
+++ b/src/server/validations/tasks.js
@@ -1,4 +1,5 @@
 import { Joi, Segments } from 'celebrate';
+import { web3Validators } from '~/common/helpers/validate';
 
 const taskKind = Joi.string().valid('vote_invitations').required();
 
@@ -12,6 +13,12 @@ const defaultValidation = {
           .items(
             Joi.object({
               to: Joi.string().email().required(),
+              booth: web3Validators.web3().address().required(),
+              boothSignature: Joi.string().required(),
+              festivalAnswerIds: Joi.array().required().items(Joi.number()),
+              festivalQuestionId: Joi.number().required(),
+              nonce: Joi.number().required(),
+              organisationId: Joi.number().allow(null),
             }),
           )
           .min(1)

--- a/test/data/tasks.json
+++ b/test/data/tasks.json
@@ -1,6 +1,20 @@
 {
   "voteInvitation": {
     "kind": "vote_invitations",
-    "data": [{ "to": "aaa@example.org" }, { "to": "bbb@example.org" }]
+    "data": [
+        {
+            "to": "aaa@example.org",
+            "festivalAnswerIds": [0, 1],
+            "festivalQuestionId": 1,
+            "nonce": 0,
+            "organisationId": 1
+        },
+        {
+            "to": "bbb@example.org",
+            "festivalAnswerIds": [0, 1],
+            "festivalQuestionId": 1,
+            "nonce": 1
+        }
+    ]
   }
 }


### PR DESCRIPTION
closes #157 

This commit adds a question field to the festival new and edit form. It
creates or updates the question inline the festival page.

This works with the exception of deleting festivals, which does not
cascade and deletes the appropriate question as well, but only sets the
`festivalId` field to `NULL`.

Further improvements that can happen:

- Initialize questions inline of the festival page. Can I deactivate
  questions without deactivating festivals?
- Prevent deletion of questions in the questions panel, since both the
  festival and question have to stay intact. Currently if either of the
  two gets deleted the UI breaks.
- Move the relation between a festival and a question from the question
  to the festival. This encodes the 1:1 relationship between festivals
  and questions on the database layer.