### PR TITLE
Download votes as a CSV file.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8642,6 +8642,11 @@
         }
       }
     },
+    "csv-stringify": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.2.tgz",
+      "integrity": "sha512-n3rIVbX6ylm1YsX2NEug9IaPV8xRnT+9/NNZbrA/bcHgOSSeqtWla6XnI/xmyu57wIw+ASCAoX1oM6EZtqJV0A=="
+    },
     "culturestake-contracts": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/culturestake-contracts/-/culturestake-contracts-1.0.28.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "compression": "^1.7.4",
     "concurrently": "^5.3.0",
     "cors": "^2.8.5",
+    "csv-stringify": "^5.6.2",
     "culturestake-contracts": "^1.0.28",
     "date-fns": "^2.17.0",
     "express": "^4.17.1",

--- a/src/client/components/ExportVotesContainer.js
+++ b/src/client/components/ExportVotesContainer.js
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import translate from '~/common/services/i18n';
+import apiRequest from '~/client/services/api';
+import { HeadingSecondaryStyle } from '~/client/styles/typography';
+import styles from '~/client/styles/variables';
+import swirl from '~/client/assets/images/swirl.svg';
+import ButtonIcon from '~/client/components/ButtonIcon';
+import { downloadAsFile } from '~/client/utils/downloads';
+
+const ExportVotesContainer = ({ path }) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const getVotesCsv = async (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+    setIsLoading(true);
+
+    const response = await apiRequest({
+      path,
+      headers: { 'Content-Type': 'text/csv' },
+    });
+
+    downloadAsFile('text/csv', response);
+
+    setIsLoading(false);
+  };
+
+  return (
+    <VoteweightsContainerStyle>
+      <HeadingSecondaryStyle>
+        {translate('ExportVotesContainer.title')}
+      </HeadingSecondaryStyle>
+
+      <ButtonIcon onClick={getVotesCsv} url={swirl} disabled={isLoading}>
+        {translate('ExportVotesContainer.buttonDownload')}
+      </ButtonIcon>
+    </VoteweightsContainerStyle>
+  );
+};
+
+export const VoteweightsContainerStyle = styled.section`
+  position: relative;
+
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  padding: 1rem;
+
+  border: 1.5px solid
+    ${(props) => (props.disabled ? styles.colors.gray : styles.colors.violet)};
+  border-radius: 20px;
+
+  color: ${(props) =>
+    props.disabled ? styles.colors.gray : styles.colors.violet};
+`;
+
+ExportVotesContainer.propTypes = {
+  path: PropTypes.arrayOf(PropTypes.string).required,
+};
+
+export default ExportVotesContainer;

--- a/src/client/services/api.js
+++ b/src/client/services/api.js
@@ -6,9 +6,8 @@ export default async function apiRequest({
   method = 'GET',
   token = null,
   body = null,
+  headers = {},
 }) {
-  const headers = {};
-
   // Add JWT authorization token when given
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;

--- a/src/client/utils/downloads.js
+++ b/src/client/utils/downloads.js
@@ -1,9 +1,9 @@
-export const downloadAsFile = (contentType, contents) => {
+export const downloadAsFile = (contentType, filename, contents) => {
   const blob = new Blob([contents], { type: contentType });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `votes-${festival}.csv`;
+  a.download = filename;
 
   const clickHandler = () => {
     setTimeout(() => {

--- a/src/client/utils/downloads.js
+++ b/src/client/utils/downloads.js
@@ -1,0 +1,17 @@
+export const downloadAsFile = (contentType, contents) => {
+  const blob = new Blob([contents], { type: contentType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `votes-${festival}.csv`;
+
+  const clickHandler = () => {
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+      a.removeEventListener('click', clickHandler);
+    }, 150);
+  };
+
+  a.addEventListener('click', clickHandler, false);
+  a.click();
+};

--- a/src/client/utils/request.js
+++ b/src/client/utils/request.js
@@ -12,7 +12,7 @@ export default async function request(customOptions) {
   } = customOptions;
 
   const defaultHeaders = {};
-  if (!(body instanceof FormData)) {
+  if (!(body instanceof FormData) && !headers['Content-Type']) {
     defaultHeaders['Content-Type'] = 'application/json';
   }
 

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -93,7 +93,10 @@ const AdminFestivalsEditForm = () => {
           )}
 
           {!isResourceLoading && (
-            <ExportVotesContainer path={['festivals', festival, 'votes']} />
+            <ExportVotesContainer
+              name={slug}
+              path={['festivals', slug, 'votes']}
+            />
           )}
 
           <DangerZone>

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -9,6 +9,7 @@ import DangerZone from '~/client/components/DangerZone';
 import FooterAdmin from '~/client/components/FooterAdmin';
 import FormFestivals from '~/client/components/FormFestivals';
 import VoteweightsContainer from '~/client/components/VoteweightsContainer';
+import ExportVotesContainer from '~/client/components/ExportVotesContainer';
 import HeaderAdmin from '~/client/components/HeaderAdmin';
 import ViewAdmin from '~/client/components/ViewAdmin';
 import notify, {
@@ -89,6 +90,10 @@ const AdminFestivalsEditForm = () => {
 
           {!isResourceLoading && (
             <VoteweightsContainer festivalId={resource.id} />
+          )}
+
+          {!isResourceLoading && (
+            <ExportVotesContainer path={['festivals', festival, 'votes']} />
           )}
 
           <DangerZone>

--- a/src/client/views/AdminQuestionsEdit.js
+++ b/src/client/views/AdminQuestionsEdit.js
@@ -7,6 +7,7 @@ import BoxRounded from '~/client/components/BoxRounded';
 import ButtonIcon from '~/client/components/ButtonIcon';
 import ButtonSubmit from '~/client/components/ButtonSubmit';
 import ContractsQuestions from '~/client/components/ContractsQuestions';
+import ExportVotesContainer from '~/client/components/ExportVotesContainer';
 import DangerZone from '~/client/components/DangerZone';
 import FooterAdmin from '~/client/components/FooterAdmin';
 import FormQuestions from '~/client/components/FormQuestions';
@@ -91,6 +92,13 @@ const AdminQuestionsEdit = () => {
               {translate('AdminQuestionsEdit.buttonNewAnswer')}
             </ButtonIcon>
           </BoxRounded>
+
+          {!isResourceLoading && (
+            <ExportVotesContainer
+              name={resource.slug}
+              path={['questions', questionId, 'votes']}
+            />
+          )}
 
           <DangerZone>
             <ButtonDelete />

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -65,6 +65,7 @@ const components = {
   ExportVotesContainer: {
     title: 'Export Votes',
     buttonDownload: 'Download votes as a CSV',
+    csvEmpty: 'No votes available to export.',
   },
   FormLogin: {
     fieldEmail: 'Your Email-address:',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -62,6 +62,10 @@ const components = {
     buttonEnable: 'Enable Ethereum wallet',
     title: 'Smart Contracts Snuggle Panel (SCSP)',
   },
+  ExportVotesContainer: {
+    title: 'Export Votes',
+    buttonDownload: 'Download votes as a CSV',
+  },
   FormLogin: {
     fieldEmail: 'Your Email-address:',
     fieldPassword: 'Your password:',

--- a/src/server/controllers/questions.js
+++ b/src/server/controllers/questions.js
@@ -77,17 +77,19 @@ const optionsRead = {
 
 async function getVotes(req, res, next) {
   if (req.get('Content-Type') === 'text/csv') {
-    const { resource } = req.locals;
+    const { resource: question } = req.locals;
 
     try {
-      const question = await Question.findOne({
-        rejectOnEmpty: true,
-        where: { festivalId: resource.id },
-      });
-
       const votes = await Vote.findAll({
         rejectOnEmpty: true,
-        where: { festivalQuestionChainId: question.chainId },
+        where: {
+          ...(question.type === 'festival'
+            ? { festivalQuestionChainId: question.chainId }
+            : undefined),
+          ...(question.type === 'artwork'
+            ? { artworkQuestionChainId: question.chainId }
+            : undefined),
+        },
       });
 
       res.header('Content-Type', 'text/csv');

--- a/src/server/routes/festivals.js
+++ b/src/server/routes/festivals.js
@@ -46,6 +46,14 @@ router.get(
 );
 
 router.get(
+  '/:slug/votes',
+  optionalAuthMiddleware,
+  validate(festivalsValidation.getVotes),
+  getFestivalResource,
+  festivalsController.getVotes,
+);
+
+router.get(
   '/:slug',
   optionalAuthMiddleware,
   validate(festivalsValidation.read),

--- a/src/server/routes/questions.js
+++ b/src/server/routes/questions.js
@@ -39,6 +39,14 @@ router.get(
   questionsController.read,
 );
 
+router.get(
+  '/:id/votes',
+  optionalAuthMiddleware,
+  validate(questionsValidation.getVotes),
+  getQuestionResource,
+  questionsController.getVotes,
+);
+
 router.post(
   '/:id',
   authMiddleware,

--- a/src/server/validations/festivals.js
+++ b/src/server/validations/festivals.js
@@ -27,6 +27,11 @@ export default {
       ...slugValidation,
     },
   },
+  getVotes: {
+    [Segments.PARAMS]: {
+      ...slugValidation,
+    },
+  },
   getQuestions: {
     [Segments.PARAMS]: {
       idOrChainId: Joi.alternatives().try(

--- a/src/server/validations/questions.js
+++ b/src/server/validations/questions.js
@@ -22,6 +22,11 @@ const createValidation = {
 };
 
 export default {
+  getVotes: {
+    [Segments.PARAMS]: {
+      ...idValidation,
+    },
+  },
   create: {
     [Segments.BODY]: {
       ...createValidation,


### PR DESCRIPTION
closes #117

This commit adds the following features:

- Add a UI component (`ExportVotesContainer`) that allows to download
  data as CSV files.
- Provide a controller template (`getVotes` in
  `server/controllers/festival.js`) how to transform data into CSV and
  send the CSV data as a file attachment back to the browser.

The UI component is already working and complete. What is missing is to
plug the right data into the CSV generation on the backend and create
controllers at the correct route.