### PR TITLE
Adapt vote page for online votes

### DIFF
--- a/src/client/components/VoteSession.js
+++ b/src/client/components/VoteSession.js
@@ -52,6 +52,7 @@ const VoteSession = ({
   festivalQuestionId,
   nonce,
   senderAddress,
+  organisationId = null,
 }) => {
   const dispatch = useDispatch();
   const { isAlternateColor } = useSelector((state) => state.app);
@@ -61,6 +62,9 @@ const VoteSession = ({
 
   // How happy is our SnuggleRain component?
   const [snuggleness, setSnuggleness] = useState(0.0);
+
+  const [latitude, setLatitude] = useState(null);
+  const [longitude, setLongitude] = useState(null);
 
   // Actual quadratic vote states, divided by the two separate vote steps
   const [creditLeft, setCreditLeft] = useState({
@@ -106,6 +110,19 @@ const VoteSession = ({
       return question.artworkId === winnerArtworkId;
     });
   }, [winnerArtworkId, data]);
+
+  useEffect(() => {
+    function showPosition(position) {
+      setLatitude(position.coords.latitude);
+      setLongitude(position.coords.longitude);
+    }
+    function getLocation() {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(showPosition);
+      }
+    }
+    getLocation();
+  });
 
   useEffect(() => {
     if (!artworkQuestionData || !artworkQuestionData.answers) {
@@ -327,6 +344,9 @@ const VoteSession = ({
       nonce,
       senderAddress,
       senderSignature,
+      organisationId,
+      latitude,
+      longitude,
     };
 
     setIsVoting(true);
@@ -557,6 +577,7 @@ VoteSession.propTypes = {
   festivalAnswerIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   festivalQuestionId: PropTypes.number.isRequired,
   nonce: PropTypes.number.isRequired,
+  organisationId: PropTypes.number,
   senderAddress: PropTypes.string.isRequired,
 };
 

--- a/src/client/components/VoteSession.js
+++ b/src/client/components/VoteSession.js
@@ -117,7 +117,7 @@ const VoteSession = ({
       setLongitude(position.coords.longitude);
     }
     function getLocation() {
-      if (navigator.geolocation) {
+      if (navigator.geolocation && data && data.online) {
         navigator.geolocation.getCurrentPosition(showPosition);
       }
     }

--- a/src/server/controllers/festivals.js
+++ b/src/server/controllers/festivals.js
@@ -33,7 +33,7 @@ import { respondWithSuccess } from '~/server/helpers/respond';
 
 const options = {
   model: Festival,
-  fields: [...festivalFields, 'images', 'artworks', 'online', 'voteweights'],
+  fields: [...festivalFields, 'images', 'artworks', 'voteweights'],
   fieldsProtected: ['documents', 'chainId'],
   include: [
     FestivalBelongsToManyArtworks,

--- a/src/server/database/associations.js
+++ b/src/server/database/associations.js
@@ -41,6 +41,7 @@ export const festivalFields = [
   'subtitle',
   'title',
   'url',
+  'online',
 ];
 export const imageFileFields = [
   ...baseFileFields,

--- a/src/server/validations/votes.js
+++ b/src/server/validations/votes.js
@@ -17,9 +17,9 @@ export default {
       nonce: Joi.number().required(),
       senderAddress: web3Validators.web3().address().required(),
       senderSignature: web3Validators.web3().signature().required(),
-      latitude: Joi.number().min(-90).max(90),
-      longitude: Joi.number().min(-180).max(180),
-      organisationId: Joi.number().positive(),
+      latitude: Joi.number().min(-90).max(90).allow(null),
+      longitude: Joi.number().min(-180).max(180).allow(null),
+      organisationId: Joi.number().positive().allow(null),
     },
   },
   results: {


### PR DESCRIPTION
Closes #108 

The vote page should now request the voter's location (for online festivals only). If provided, the location is sent to the vote endpoint. There is also a parameter `organisationId` that may be passed optionally to the `voteSession` container, if it is passed, it also sent to the vote endpoint