### PR TITLE
Create answer properties inline of the finder field

### DIFF
--- a/src/client/components/Finder.js
+++ b/src/client/components/Finder.js
@@ -21,6 +21,7 @@ const Finder = ({
   selectParam = searchParam,
   onChange,
   value,
+  onCreate,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isQueryEmpty, setIsQueryEmpty] = useState(true);
@@ -106,6 +107,13 @@ const Finder = ({
     search(query);
   }, [query, value]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const createItem = async () => {
+    setIsLoading(true);
+    const resource = await onCreate(query);
+    if (resource) onSelect(resource);
+    setIsLoading(false);
+  };
+
   return (
     <FinderStyle>
       {isLoading && (
@@ -132,6 +140,14 @@ const Finder = ({
         searchParam={searchParam}
         onClick={onSelect}
       />
+
+      {onCreate && !isQueryEmpty && searchResults.length === 0 && (
+        <FinderResultStyle>
+          <FinderResultItemStyle onClick={createItem}>
+            Create &quot;{query}&quot;
+          </FinderResultItemStyle>
+        </FinderResultStyle>
+      )}
     </FinderStyle>
   );
 };
@@ -180,6 +196,7 @@ Finder.propTypes = {
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  onCreate: PropTypes.func,
   placeholder: PropTypes.string.isRequired,
   queryPath: PropTypes.arrayOf(PropTypes.string).isRequired,
   searchParam: PropTypes.string.isRequired,

--- a/src/client/components/FormAnswers.js
+++ b/src/client/components/FormAnswers.js
@@ -1,12 +1,20 @@
 import Joi from 'joi';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import InputFinderField from '~/client/components/InputFinderField';
 import InputHiddenField from '~/client/components/InputHiddenField';
 import translate from '~/common/services/i18n';
+import apiRequest from '~/client/services/api';
+import notify, {
+  NotificationsTypes,
+} from '~/client/store/notifications/actions';
 
 const FormAnswers = ({ question, festivalId, isDisabled }) => {
+  const dispatch = useDispatch();
+  const { token } = useSelector((state) => state.app);
+
   const schema = {};
   if (question.type === 'festival') {
     schema.artworkId = Joi.number()
@@ -17,6 +25,32 @@ const FormAnswers = ({ question, festivalId, isDisabled }) => {
       .required()
       .error(new Error(translate('validations.artworkRequired')));
   }
+
+  const createProperty = async (title) => {
+    try {
+      const response = await apiRequest({
+        path: ['properties'],
+        method: 'PUT',
+        body: { title },
+        token,
+      });
+      dispatch(
+        notify({
+          text: translate('FormAnswers.notificationPropertySuccess', {
+            title: response.title,
+          }),
+        }),
+      );
+      return response;
+    } catch (e) {
+      dispatch(
+        notify({
+          text: translate('default.errorMessage'),
+          type: NotificationsTypes.ERROR,
+        }),
+      );
+    }
+  };
 
   const filter = (item) => {
     const filterParam =
@@ -60,6 +94,7 @@ const FormAnswers = ({ question, festivalId, isDisabled }) => {
           queryPath={['properties']}
           searchParam={'title'}
           validate={schema.propertyId}
+          onCreateCallback={createProperty}
         />
       )}
     </Fragment>

--- a/src/client/components/InputFinderField.js
+++ b/src/client/components/InputFinderField.js
@@ -12,6 +12,7 @@ const InputFinderField = ({
   label,
   name,
   onChangeCallback = null,
+  onCreateCallback,
   placeholder,
   queryPath,
   searchParam,
@@ -53,6 +54,7 @@ const InputFinderField = ({
         selectParam={selectParam}
         value={value}
         onChange={onChange}
+        onCreate={onCreateCallback}
       />
     </InputFieldset>
   );
@@ -65,6 +67,7 @@ InputFinderField.propTypes = {
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onChangeCallback: PropTypes.func,
+  onCreateCallback: PropTypes.func,
   placeholder: PropTypes.string.isRequired,
   queryPath: PropTypes.arrayOf(PropTypes.string).isRequired,
   searchParam: PropTypes.string.isRequired,

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -79,6 +79,9 @@ const components = {
     buttonDownload: 'Download votes as a CSV',
     csvEmpty: 'No votes available to export.',
   },
+  FormAnswers: {
+    notificationPropertySuccess: 'Created property {title}',
+  },
   FormLogin: {
     fieldEmail: 'Your Email-address:',
     fieldPassword: 'Your password:',


### PR DESCRIPTION
It allows to create a new property from within the answer new page. This
mechanism can be extended to other finder input fields by setting the
`onCreateCallback`. This callback should return the created resource in
order to pre-fill the finder field correctly.

closes #176