### PR TITLE
Organisations logos

### DIFF
--- a/src/client/components/FormOrganisations.js
+++ b/src/client/components/FormOrganisations.js
@@ -3,12 +3,15 @@ import React, { Fragment } from 'react';
 
 import InputField from '~/client/components/InputField';
 import InputTextareaField from '~/client/components/InputTextareaField';
+import InputUploadField from '~/client/components/InputUploadField';
 import translate from '~/common/services/i18n';
+import { imagesValidation } from '~/common/helpers/validate';
 
 const FormOrganisations = () => {
   const schema = {
     description: Joi.string().max(2000).required(),
     name: Joi.string().max(128).required(),
+    images: imagesValidation.required().max(10),
   };
 
   return (
@@ -24,6 +27,14 @@ const FormOrganisations = () => {
         label={translate('FormOrganisations.fieldDescription')}
         name="description"
         validate={schema.description}
+      />
+
+      <InputUploadField
+        isImageUpload
+        isMultipleFilesAllowed
+        label={translate('FormOrganisations.fieldImages')}
+        name="images"
+        validate={schema.images}
       />
     </Fragment>
   );

--- a/src/client/components/FormOrganisations.js
+++ b/src/client/components/FormOrganisations.js
@@ -11,7 +11,7 @@ const FormOrganisations = () => {
   const schema = {
     description: Joi.string().max(2000).required(),
     name: Joi.string().max(128).required(),
-    images: imagesValidation.required().max(10),
+    images: imagesValidation.required().max(1),
   };
 
   return (
@@ -31,7 +31,6 @@ const FormOrganisations = () => {
 
       <InputUploadField
         isImageUpload
-        isMultipleFilesAllowed
         label={translate('FormOrganisations.fieldImages')}
         name="images"
         validate={schema.images}

--- a/src/client/components/InputUploadField.js
+++ b/src/client/components/InputUploadField.js
@@ -201,10 +201,13 @@ const InputUploadField = ({
         type="file"
         onChange={onChangeFiles}
       />
-
-      <ButtonOutline disabled={isPending} onClick={onClickUpload}>
-        {translate('InputUploadField.buttonSelectFiles')}
-      </ButtonOutline>
+      {(isMultipleFilesAllowed || filesData.length === 0) && (
+        <ButtonOutline disabled={isPending} onClick={onClickUpload}>
+          {isMultipleFilesAllowed
+            ? translate('InputUploadField.buttonSelectFiles')
+            : translate('InputUploadField.buttonSelectFile')}
+        </ButtonOutline>
+      )}
     </InputFieldsetRounded>
   );
 };

--- a/src/client/views/AdminOrganisationsEdit.js
+++ b/src/client/views/AdminOrganisationsEdit.js
@@ -21,7 +21,7 @@ const AdminOrganisationsEdit = () => {
   const dispatch = useDispatch();
 
   const { ButtonDelete, Form } = useEditForm({
-    fields: ['name', 'description'],
+    fields: ['name', 'description', 'images'],
     resourcePath: ['organisations', slug],
     returnUrl,
     onNotFound: () => {

--- a/src/client/views/AdminOrganisationsNew.js
+++ b/src/client/views/AdminOrganisationsNew.js
@@ -18,7 +18,7 @@ const AdminOrganisationsNew = () => {
   const returnUrl = '/admin/organisations';
 
   const { Form } = useNewForm({
-    fields: ['name', 'description'],
+    fields: ['name', 'description', 'images'],
     resourcePath: ['organisations'],
     returnUrl,
     onSuccess: ({ name }) => {

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -158,6 +158,7 @@ const components = {
   },
   InputUploadField: {
     buttonRemoveFile: 'Remove',
+    buttonSelectFile: 'Select file',
     buttonSelectFiles: 'Select files',
   },
   InputStickerField: {

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -138,7 +138,7 @@ const components = {
   FormOrganisations: {
     fieldDescription: 'Description:',
     fieldName: 'Name:',
-    fieldImages: 'Organisation image',
+    fieldImages: 'Organisation logo',
   },
   FormVoteweights: {
     fieldType: 'Type:',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -138,6 +138,7 @@ const components = {
   FormOrganisations: {
     fieldDescription: 'Description:',
     fieldName: 'Name:',
+    fieldImages: 'Organisation image',
   },
   FormVoteweights: {
     fieldType: 'Type:',

--- a/src/server/controllers/organisations.js
+++ b/src/server/controllers/organisations.js
@@ -1,10 +1,22 @@
 import Organisation from '~/server/models/organisation';
 import baseController from '~/server/controllers';
-import { organisationFields } from '~/server/database/associations';
+import {
+  OrganisationHasManyImages,
+  organisationFields,
+  imageFileFields,
+} from '~/server/database/associations';
 
 const options = {
   model: Organisation,
-  fields: [...organisationFields],
+  fields: [...organisationFields, 'images'],
+  include: [OrganisationHasManyImages],
+  associations: [
+    {
+      association: OrganisationHasManyImages,
+      destroyCascade: true,
+      fields: [...imageFileFields],
+    },
+  ],
 };
 
 function create(req, res, next) {

--- a/src/server/database/associations.js
+++ b/src/server/database/associations.js
@@ -5,6 +5,7 @@ import Document from '~/server/models/document';
 import Festival from '~/server/models/festival';
 import FestivalArtwork from '~/server/models/festivalArtwork';
 import Image from '~/server/models/image';
+import Organisation from '~/server/models/organisation';
 import Property from '~/server/models/property';
 import Question from '~/server/models/question';
 import Vote from '~/server/models/vote';
@@ -49,7 +50,7 @@ export const imageFileFields = [
   'urlThresholdThumb',
   'urlThumb',
 ];
-export const organisationFields = ['description', 'name'];
+export const organisationFields = ['description', 'name', 'imageId'];
 export const propertyFields = ['title'];
 export const questionFields = [
   'title',
@@ -181,6 +182,17 @@ export const FestivalHasManyVoteweights = Festival.hasMany(Voteweight, {
   ...attachableMixin,
   foreignKey: 'festivalId',
   as: 'voteweights',
+});
+
+// Organisation
+
+export const OrganisationHasManyImages = Organisation.hasMany(Image, {
+  ...attachableMixin,
+  allowNull: true,
+  scope: {
+    attachableType: 'organisation',
+  },
+  as: 'images',
 });
 
 // Property

--- a/src/server/validations/organisations.js
+++ b/src/server/validations/organisations.js
@@ -9,7 +9,7 @@ import {
 
 const defaultValidation = {
   description: Joi.string().max(2000).required(),
-  images: imagesValidation.max(10),
+  images: imagesValidation.max(1),
   name: Joi.string().max(128).required(),
 };
 

--- a/src/server/validations/organisations.js
+++ b/src/server/validations/organisations.js
@@ -1,5 +1,6 @@
 import { Joi, Segments } from 'celebrate';
 
+import { imagesValidation } from '~/common/helpers/validate';
 import {
   paginationValidation,
   queryValidation,
@@ -8,6 +9,7 @@ import {
 
 const defaultValidation = {
   description: Joi.string().max(2000).required(),
+  images: imagesValidation.max(10),
   name: Joi.string().max(128).required(),
 };
 


### PR DESCRIPTION
Adds the image (logo) upload component to organisations views. Currently allows for more than one image/logo to be uploaded.

I noticed it is possible to add more than one organisation with the same name - thought perhaps changing this would become more complex as it could require e.g. adding an additional column such as 'location' to the view, so that if two organisations in different locations happen to have the same name, they can be differentiated. Or we can leave it as is :)