### PR TITLE
Hotspot voting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,12 @@ PAYER_ADDRESS=0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e
 BOOTH_PRIV_KEY=c72e8acaf6e111d568918c13e4ae033bceb82d32ef4f4a7e9c42504d09e7d3d8
 ADMIN_PRIV_KEY=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
 
+# Hotspot config
+HOTSPOT_PRIV_KEY=
+HOTSPOT_ADDRESS=
+HOTSPOT_FESTIVAL_QUESTION=
+HOTSPOT_MAX_VOTES=
+
 # Barcode helper service
 BARCODE_URL="https://barcode.tec-it.com/barcode.ashx?data={barcode}&code=Code128&multiplebarcodes=false&translate-esc=false&unit=Fit&dpi=600&imagetype=jpg&rotation=0&color=%23000000&bgcolor=%23ffffff&codepage=&qunit=Mm&quiet=0"
 

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ BOOTH_PRIV_KEY=c72e8acaf6e111d568918c13e4ae033bceb82d32ef4f4a7e9c42504d09e7d3d8
 ADMIN_PRIV_KEY=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
 
 # Hotspot config
+# set to the private key and address that are stored on the computer serving the hotspot site
+# hotspot_festival_question should be the id of the the festival-question for the festival that the hotspot is voting on
+# max votes can be set to any number, and will limit the amount of votes that can be cast at the hotspot
+# for production, these should all be unset
 HOTSPOT_PRIV_KEY=
 HOTSPOT_ADDRESS=
 HOTSPOT_FESTIVAL_QUESTION=

--- a/src/client/components/VoteSession.js
+++ b/src/client/components/VoteSession.js
@@ -54,6 +54,7 @@ const VoteSession = ({
   nonce,
   senderAddress,
   organisationId = null,
+  voteCallback,
 }) => {
   const dispatch = useDispatch();
   const { isAlternateColor } = useSelector((state) => state.app);
@@ -352,6 +353,10 @@ const VoteSession = ({
 
     setIsVoting(true);
 
+    if (voteCallback) {
+      voteCallback();
+    }
+
     // Go vote!
     await dispatch(vote(voteData, requestId));
   };
@@ -584,6 +589,7 @@ VoteSession.propTypes = {
   nonce: PropTypes.number.isRequired,
   organisationId: PropTypes.number,
   senderAddress: PropTypes.string.isRequired,
+  voteCallback: PropTypes.function,
 };
 
 VoteSessionArtwork.propTypes = {

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -44,6 +44,7 @@ import FestivalsProfile from '~/client/views/FestivalsProfile';
 import Invitations from '~/client/views/Invitations';
 import RemoteVote from '~/client/views/RemoteVote';
 import Homepage from '~/client/views/Homepage';
+import HotspotVote from '~/client/views/HotspotVote';
 import NotFound from '~/client/views/NotFound';
 import Vote from '~/client/views/Vote';
 
@@ -134,6 +135,11 @@ const Routes = () => (
       component={Vote}
       exact
       path="/vote"
+    />
+    <PublicRoute
+      component={HotspotVote}
+      exact
+      path="/hotspot"
     />
     <PublicRoute
       component={Booth}

--- a/src/client/views/HotspotVote.js
+++ b/src/client/views/HotspotVote.js
@@ -8,7 +8,6 @@ import notify, {
 } from '~/client/store/notifications/actions';
 import translate from '~/common/services/i18n';
 import { initializeVote, resetVote } from '~/client/store/vote/actions';
-import { useParams } from 'react-router-dom';
 import { useResource } from '~/client/hooks/requests';
 import Spinner from '~/client/components/Spinner';
 import { HeadingPrimaryStyle } from '~/client/styles/typography';
@@ -16,7 +15,7 @@ import { ContainerStyle } from '~/client/styles/layout';
 import ColorSection from '~/client/components/ColorSection';
 import Header from '~/client/components/Header';
 
-const RemoteVote = () => {
+const HotspotVote = () => {
   const dispatch = useDispatch();
   const vote = useSelector((state) => state.vote);
   const [isError, setIsError] = useState(false);
@@ -28,34 +27,34 @@ const RemoteVote = () => {
       setIsError(true);
       dispatch(
         notify({
-          text: translate('RemoteVote.errorNotFound'),
+          text: translate('HotspotVote.errorNotEnabled'),
         }),
       );
     },
   });
 
   useEffect(() => {
-    if (isInvitationLoading || isError) {
+    if (isVoteDataLoading || isError) {
       return;
     }
 
     try {
       dispatch(resetVote());
-      dispatch(initializeVote(invitation));
+      dispatch(initializeVote(voteData));
     } catch (error) {
       dispatch(
         notify({
-          text: translate('RemoteVote.errorInvalidVoteData'),
+          text: translate('HotspotVote.errorInvalidVoteData'),
           type: NotificationsTypes.ERROR,
         }),
       );
     }
-  }, [dispatch, invitation, isInvitationLoading, isError]);
+  }, [dispatch, voteData, isVoteDataLoading, isError]);
 
   return (
     <Fragment>
       <View>
-        {isVoteReady && !isInvitationLoading && !isError ? (
+        {isVoteReady && !isVoteDataLoading && !isError ? (
           <VoteSession
             boothSignature={vote.boothSignature}
             festivalAnswerIds={vote.festivalAnswerIds}
@@ -68,7 +67,7 @@ const RemoteVote = () => {
             <ContainerStyle>
               <ColorSection>
                 <HeadingPrimaryStyle>
-                  {translate('RemoteVote.notFoundTitle')}
+                  {translate('HotspotVote.notEnabled')}
                 </HeadingPrimaryStyle>
               </ColorSection>
             </ContainerStyle>
@@ -81,4 +80,4 @@ const RemoteVote = () => {
   );
 };
 
-export default RemoteVote;
+export default HotspotVote;

--- a/src/client/views/HotspotVote.js
+++ b/src/client/views/HotspotVote.js
@@ -34,6 +34,10 @@ const HotspotVote = () => {
     },
   });
 
+  const voteCallback = () => {
+    setItem(`hasVoted-${voteData.festivalQuestionId}`, true);
+  };
+
   useEffect(() => {
     if (isVoteDataLoading || isError) {
       return;
@@ -47,12 +51,13 @@ const HotspotVote = () => {
           type: NotificationsTypes.ERROR,
         }),
       );
+      return;
     }
 
     try {
       dispatch(resetVote());
       dispatch(initializeVote(voteData));
-      setItem(`hasVoted-${voteData.festivalQuestionId}`, true);
+      //setItem(`hasVoted-${voteData.festivalQuestionId}`, true);
     } catch (error) {
       dispatch(
         notify({
@@ -73,6 +78,7 @@ const HotspotVote = () => {
             festivalQuestionId={vote.festivalQuestionId}
             nonce={vote.nonce}
             senderAddress={vote.address}
+            voteCallback={voteCallback}
           />
         ) : isError ? (
           <Header>

--- a/src/client/views/HotspotVote.js
+++ b/src/client/views/HotspotVote.js
@@ -14,6 +14,7 @@ import { HeadingPrimaryStyle } from '~/client/styles/typography';
 import { ContainerStyle } from '~/client/styles/layout';
 import ColorSection from '~/client/components/ColorSection';
 import Header from '~/client/components/Header';
+import { isAvailable, hasItem, setItem } from '~/client/utils/storage';
 
 const HotspotVote = () => {
   const dispatch = useDispatch();
@@ -38,9 +39,20 @@ const HotspotVote = () => {
       return;
     }
 
+    if (isAvailable && hasItem(`hasVoted-${voteData.festivalQuestionId}`)) {
+      setIsError(true);
+      dispatch(
+        notify({
+          text: translate('HotspotVote.errorAlreadyVoted'),
+          type: NotificationsTypes.ERROR,
+        }),
+      );
+    }
+
     try {
       dispatch(resetVote());
       dispatch(initializeVote(voteData));
+      setItem(`hasVoted-${voteData.festivalQuestionId}`, true);
     } catch (error) {
       dispatch(
         notify({
@@ -49,7 +61,7 @@ const HotspotVote = () => {
         }),
       );
     }
-  }, [dispatch, voteData, isVoteDataLoading, isError]);
+  }, [dispatch, voteData, isVoteDataLoading, isError, setIsError]);
 
   return (
     <Fragment>

--- a/src/client/views/HotspotVote.js
+++ b/src/client/views/HotspotVote.js
@@ -1,0 +1,84 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import View from '~/client/components/View';
+import VoteSession from '~/client/components/VoteSession';
+import notify, {
+  NotificationsTypes,
+} from '~/client/store/notifications/actions';
+import translate from '~/common/services/i18n';
+import { initializeVote, resetVote } from '~/client/store/vote/actions';
+import { useParams } from 'react-router-dom';
+import { useResource } from '~/client/hooks/requests';
+import Spinner from '~/client/components/Spinner';
+import { HeadingPrimaryStyle } from '~/client/styles/typography';
+import { ContainerStyle } from '~/client/styles/layout';
+import ColorSection from '~/client/components/ColorSection';
+import Header from '~/client/components/Header';
+
+const RemoteVote = () => {
+  const dispatch = useDispatch();
+  const vote = useSelector((state) => state.vote);
+  const [isError, setIsError] = useState(false);
+
+  const isVoteReady = !!vote.address;
+
+  const [voteData, isVoteDataLoading] = useResource(['hotspot'], {
+    onError: () => {
+      setIsError(true);
+      dispatch(
+        notify({
+          text: translate('RemoteVote.errorNotFound'),
+        }),
+      );
+    },
+  });
+
+  useEffect(() => {
+    if (isInvitationLoading || isError) {
+      return;
+    }
+
+    try {
+      dispatch(resetVote());
+      dispatch(initializeVote(invitation));
+    } catch (error) {
+      dispatch(
+        notify({
+          text: translate('RemoteVote.errorInvalidVoteData'),
+          type: NotificationsTypes.ERROR,
+        }),
+      );
+    }
+  }, [dispatch, invitation, isInvitationLoading, isError]);
+
+  return (
+    <Fragment>
+      <View>
+        {isVoteReady && !isInvitationLoading && !isError ? (
+          <VoteSession
+            boothSignature={vote.boothSignature}
+            festivalAnswerIds={vote.festivalAnswerIds}
+            festivalQuestionId={vote.festivalQuestionId}
+            nonce={vote.nonce}
+            senderAddress={vote.address}
+          />
+        ) : isError ? (
+          <Header>
+            <ContainerStyle>
+              <ColorSection>
+                <HeadingPrimaryStyle>
+                  {translate('RemoteVote.notFoundTitle')}
+                </HeadingPrimaryStyle>
+              </ColorSection>
+            </ContainerStyle>
+          </Header>
+        ) : (
+          <Spinner />
+        )}
+      </View>
+    </Fragment>
+  );
+};
+
+export default RemoteVote;

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -526,6 +526,7 @@ ccc@example.org`,
   HotspotVote: {
     errorNotEnabled: 'This features is not enabled',
     errorInvalidVoteData: 'Invalid vote data',
+    errorAlreadyVoted: 'You already voted!',
     notEnabled: 'Unauthorized',
   },
 };

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -523,6 +523,11 @@ ccc@example.org`,
     errorScannerFailure: 'Something went wrong with your camera',
     errorInvalidVoteData: 'QR Code is invalid',
   },
+  HotspotVote: {
+    errorNotEnabled: 'This features is not enabled',
+    errorInvalidVoteData: 'Invalid vote data',
+    notEnabled: 'Unauthorized',
+  },
 };
 
 export default {

--- a/src/server/controllers/hotspot.js
+++ b/src/server/controllers/hotspot.js
@@ -1,0 +1,31 @@
+import httpStatus from 'http-status';
+
+import { respondWithError, respondWithSuccess } from '~/server/helpers/respond';
+import { signBooth } from '~/common/services/vote';
+
+async function read(req, res) {
+  const hotspotAddress = process.env.HOTSPOT_ADDRESS;
+  const hotspotPrivKey = process.env.HOTSPOT_PRIV_KEY;
+  const hotspotFestivalQuestion = process.env.HOTSPOT_FESTIVAL;
+  //const hotspotMaxVotes = process.env.HOTSPOT_MAX_VOTES;
+
+  if (!hotspotPrivKey || !hotspotAddress || !hotspotFestivalQuestion) {
+    respondWithError(res, { message: 'Unauthorized' }, httpStatus.UNAUTHORIZED);
+  }
+
+  const nonce = 0;
+  const festivalAnswerIds = [];
+
+  const voteData = {
+    booth: hotspotAddress,
+    boothSignature: signBooth(),
+    nonce,
+    festivalAnswerIds,
+    festivalQuestionId: hotspotFestivalQuestion,
+  };
+  return respondWithSuccess(res, voteData);
+}
+
+export default {
+  read,
+};

--- a/src/server/controllers/hotspot.js
+++ b/src/server/controllers/hotspot.js
@@ -2,19 +2,32 @@ import httpStatus from 'http-status';
 
 import { respondWithError, respondWithSuccess } from '~/server/helpers/respond';
 import { signBooth } from '~/common/services/vote';
+import Answers from '~/server/models/answer';
 
 async function read(req, res) {
   const hotspotAddress = process.env.HOTSPOT_ADDRESS;
   const hotspotPrivKey = process.env.HOTSPOT_PRIV_KEY;
-  const hotspotFestivalQuestion = process.env.HOTSPOT_FESTIVAL;
-  //const hotspotMaxVotes = process.env.HOTSPOT_MAX_VOTES;
+  const hotspotFestivalQuestion = process.env.HOTSPOT_FESTIVAL_QUESTION;
+  const hotspotMaxVotes = process.env.HOTSPOT_MAX_VOTES;
+  const nonce = 0;
 
   if (!hotspotPrivKey || !hotspotAddress || !hotspotFestivalQuestion) {
     respondWithError(res, { message: 'Unauthorized' }, httpStatus.UNAUTHORIZED);
   }
 
-  const nonce = 0;
-  const festivalAnswerIds = [];
+  if (nonce > hotspotMaxVotes) {
+    respondWithError(
+      res,
+      { message: 'Unprocessable' },
+      httpStatus.UNPROCESSABLE_ENTITY,
+    );
+  }
+
+  const answers = await Answers.find({
+    where: { questionId: hotspotFestivalQuestion },
+  });
+
+  const festivalAnswerIds = answers.map((answer) => answer.id);
 
   const voteData = {
     booth: hotspotAddress,

--- a/src/server/controllers/hotspot.js
+++ b/src/server/controllers/hotspot.js
@@ -2,19 +2,36 @@ import httpStatus from 'http-status';
 
 import { respondWithError, respondWithSuccess } from '~/server/helpers/respond';
 import { signBooth } from '~/common/services/vote';
+import { isVotingBoothInitialized } from '~/common/services/contracts/booths';
 import Answers from '~/server/models/answer';
 
 async function read(req, res) {
-  const hotspotAddress = process.env.HOTSPOT_ADDRESS;
+  const hotspotAddress = null; //process.env.HOTSPOT_ADDRESS;
   const hotspotPrivKey = process.env.HOTSPOT_PRIV_KEY;
-  const hotspotFestivalQuestion = process.env.HOTSPOT_FESTIVAL_QUESTION;
+  const hotspotFestivalQuestion = parseInt(
+    process.env.HOTSPOT_FESTIVAL_QUESTION,
+  );
   const hotspotMaxVotes = process.env.HOTSPOT_MAX_VOTES;
   const nonce = 0;
 
-  if (!hotspotPrivKey || !hotspotAddress || !hotspotFestivalQuestion) {
+  // cannot vote if the basic variables are not set
+  if (
+    !hotspotPrivKey ||
+    !hotspotAddress ||
+    !hotspotFestivalQuestion ||
+    !hotspotMaxVotes
+  ) {
     respondWithError(res, { message: 'Unauthorized' }, httpStatus.UNAUTHORIZED);
   }
 
+  const isInitialized = await isVotingBoothInitialized(hotspotAddress);
+
+  // the signature supplied by this endpoint will not be valid if the booth isn't initalized
+  if (!isInitialized) {
+    respondWithError(res, { message: 'Unauthorized' }, httpStatus.UNAUTHORIZED);
+  }
+
+  // this is a basic safety check, to limit the damage if this endpoint were being abused
   if (nonce > hotspotMaxVotes) {
     respondWithError(
       res,
@@ -23,7 +40,8 @@ async function read(req, res) {
     );
   }
 
-  const answers = await Answers.find({
+  // for hotspot votes, we assume all answers were/could be seen by the voter
+  const answers = await Answers.findAll({
     where: { questionId: hotspotFestivalQuestion },
   });
 
@@ -31,7 +49,11 @@ async function read(req, res) {
 
   const voteData = {
     booth: hotspotAddress,
-    boothSignature: signBooth(),
+    boothSignature: signBooth({
+      festivalAnswerIds,
+      privateKey: hotspotPrivKey,
+      nonce,
+    }),
     nonce,
     festivalAnswerIds,
     festivalQuestionId: hotspotFestivalQuestion,

--- a/src/server/routes/hotspot.js
+++ b/src/server/routes/hotspot.js
@@ -1,0 +1,11 @@
+import express from 'express';
+
+import hotspotController from '~/server/controllers/hotspot';
+import hotspotValidation from '~/server/validations/hotspot';
+import validate from '~/server/services/validate';
+
+const router = express.Router();
+
+router.get('/', validate(hotspotValidation.read), hotspotController.read);
+
+export default router;

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -8,6 +8,7 @@ import artworksRouter from '~/server/routes/artworks';
 import authMiddleware from '~/server/middlewares/passport';
 import authRouter from '~/server/routes/auth';
 import festivalsRouter from '~/server/routes/festivals';
+import hotspotRouter from '~/server/routes/hotspot';
 import organisationsRouter from '~/server/routes/organisations';
 import propertiesRouter from '~/server/routes/properties';
 import questionsRouter from '~/server/routes/questions';
@@ -52,6 +53,8 @@ router.use('/voteweights', voteweightsRouter);
 router.use('/tasks', tasksRouter);
 
 router.use('/invitations', invitationsRouter);
+
+router.use('/hotspot', hotspotRouter);
 
 router.use(() => {
   throw new APIError(httpStatus.NOT_FOUND);

--- a/src/server/services/redis.js
+++ b/src/server/services/redis.js
@@ -17,6 +17,15 @@ export function getFromRedis(key) {
   });
 }
 
+export function incrementInRedis(key) {
+  return new Promise((res, rej) => {
+    client.incr(key, (err, result) => {
+      if (err) rej(err);
+      res(result);
+    });
+  });
+}
+
 export function setInRedis(key, value, ...opts) {
   return new Promise((res, rej) => {
     client.set(key, value, ...opts, (err, result) => {

--- a/src/server/validations/hotspot.js
+++ b/src/server/validations/hotspot.js
@@ -1,0 +1,11 @@
+import { Segments } from 'celebrate';
+
+const paramsValidation = {};
+
+export default {
+  read: {
+    [Segments.PARAMS]: {
+      ...paramsValidation,
+    },
+  },
+};

--- a/test/data/organisations.json
+++ b/test/data/organisations.json
@@ -1,11 +1,13 @@
 {
     "collectivise": {
       "name": "orbits",
-      "description": "a collective"
+      "description": "a collective",
+      "images": []
     },
     "cooperate": {
       "name": "larva",
-      "description": "a cooperative"
+      "description": "a cooperative",
+      "images": []
     }
   }
   

--- a/test/hotspot.test.js
+++ b/test/hotspot.test.js
@@ -111,8 +111,6 @@ describe('Hotspot', () => {
     });
 
     describe('after booth is initialized', () => {
-      let env = process.env;
-
       beforeAll(async () => {
         process.env.HOTSPOT_ADDRESS = env.HOTSPOT_ADDRESS;
         process.env.HOTSPOT_PRIV_KEY = env.HOTSPOT_PRIV_KEY;
@@ -148,50 +146,5 @@ describe('Hotspot', () => {
           .expect(httpStatus.UNPROCESSABLE_ENTITY);
       });
     });
-
-    //   it('should fail to send vote invitations when unauthorized', async () => {
-    //     await expectNoTasks(queue);
-
-    //     const booth = web3.eth.accounts.create();
-    //     const voteInvitationsData = tasksData.voteInvitation.data.map(
-    //       (invitation) => {
-    //         return {
-    //           ...invitation,
-    //           booth: booth.address,
-    //           boothSignature: web3.eth.accounts.sign(
-    //             packBooth([invitation.festivalAnswerIds], invitation.nonce),
-    //             booth.privateKey,
-    //           ).signature,
-    //         };
-    //       },
-    //     );
-
-    //     await request(app)
-    //       .put('/api/tasks')
-    //       .send({ ...tasksData.voteInvitation, data: voteInvitationsData })
-    //       .expect(httpStatus.UNAUTHORIZED);
-
-    //     await expectNoTasks(queue);
-    //   });
-
-    //   it('should fail with no recipients', async () => {
-    //     const { kind } = tasksData.voteInvitation;
-
-    //     await Promise.all([
-    //       // No recipients.
-    //       authRequest
-    //         .put('/api/tasks')
-    //         .send({ kind, data: [] })
-    //         .expect(httpStatus.BAD_REQUEST),
-    //       // Missing recipients.
-    //       authRequest
-    //         .put('/api/tasks')
-    //         .send({ kind, data: [{ xxx: 'missing to field' }] })
-    //         .expect(httpStatus.BAD_REQUEST),
-    //     ]);
-
-    //     await expectNoTasks(queue);
-    //   });
-    // });
   });
 });

--- a/test/hotspot.test.js
+++ b/test/hotspot.test.js
@@ -1,0 +1,197 @@
+import httpStatus from 'http-status';
+
+import { initializeDatabase } from './helpers/database';
+import web3 from '~/common/services/web3';
+import { closeRedis } from '~/server/services/redis';
+import request from 'supertest';
+import app from '~/server';
+import artworksData from './data/artworks';
+import propertiesData from './data/properties';
+import festivalsData from './data/festivals';
+import { put } from './helpers/requests';
+import { isFestivalInitialized } from '~/common/services/contracts/festivals';
+import { isVotingBoothInitialized } from '~/common/services/contracts/booths';
+import {
+  initAnswer,
+  initQuestion,
+  initFestival,
+  initVotingBooth,
+} from './helpers/transactions';
+import {
+  adminContract,
+  getQuestionContract,
+} from '~/common/services/contracts';
+import { timestamp } from './helpers/constants';
+
+describe('Hotspot', () => {
+  let propertyData;
+  let artworkData;
+  let festivalData;
+  let artworkQuestionContract;
+  let festivalQuestionContract;
+  let festivalAnswerData;
+  let propertyAnswerData;
+  let env = process.env;
+
+  beforeAll(async () => {
+    await initializeDatabase();
+
+    artworkData = await put('/api/artworks', artworksData.davinci);
+    propertyData = await put('/api/properties', propertiesData.aProperty);
+
+    festivalData = await put('/api/festivals', festivalsData.barbeque);
+
+    // Use chainId from contract migrations
+    festivalData.chainId = web3.utils.sha3('festival');
+    const festivalInitialized = await isFestivalInitialized(
+      festivalData.chainId,
+    );
+    if (!festivalInitialized) {
+      await initFestival(
+        adminContract,
+        festivalData.chainId,
+        timestamp() + 20,
+        timestamp() + 100000,
+      );
+    }
+
+    // Set up first question contract for artwork answers on an festival
+    const festivalQuestionData = await put('/api/questions', {
+      title: 'What was your favorite artwork of this festival?',
+      type: 'festival',
+      festivalId: festivalData.id,
+    });
+
+    const festivalQuestionAddress = await initQuestion(
+      adminContract,
+      festivalQuestionData.chainId,
+      festivalData.chainId,
+    );
+    festivalQuestionContract = getQuestionContract(festivalQuestionAddress);
+
+    // Set up second question contract for property answers on an artwork
+    const artworkQuestionData = await put('/api/questions', {
+      title: 'What aspect of this artwork did you like and how much?',
+      type: 'artwork',
+      festivalId: festivalData.id,
+      artworkId: artworkData.id,
+    });
+    const artworkQuestionAddress = await initQuestion(
+      adminContract,
+      artworkQuestionData.chainId,
+      festivalData.chainId,
+    );
+    artworkQuestionContract = getQuestionContract(artworkQuestionAddress);
+
+    // Add possible answers to API
+    festivalAnswerData = await put('/api/answers', {
+      artworkId: artworkData.id,
+      questionId: festivalQuestionData.id,
+    });
+    propertyAnswerData = await put('/api/answers', {
+      propertyId: propertyData.id,
+      questionId: artworkQuestionData.id,
+    });
+
+    // Use chainId from API to create answer on blockchain
+    await initAnswer(festivalQuestionContract, festivalAnswerData.chainId);
+    await initAnswer(artworkQuestionContract, propertyAnswerData.chainId);
+  });
+
+  afterAll(async () => {
+    await closeRedis();
+  });
+
+  describe('GET /api/hotspot', () => {
+    it('should fail when the hotspot booth is not initialized', async () => {
+      const falseBooth = web3.eth.accounts.create();
+      process.env.HOTSPOT_ADDRESS = falseBooth.address;
+      process.env.HOTSPOT_PRIV_KEY = falseBooth.privateKey;
+      await request(app).get('/api/hotspot').expect(httpStatus.UNAUTHORIZED);
+    });
+
+    describe('after booth is initialized', () => {
+      let env = process.env;
+
+      beforeAll(async () => {
+        process.env.HOTSPOT_ADDRESS = env.HOTSPOT_ADDRESS;
+        process.env.HOTSPOT_PRIV_KEY = env.HOTSPOT_PRIV_KEY;
+        const boothInitialized = await isVotingBoothInitialized(
+          env.HOTSPOT_ADDRESS,
+        );
+        if (!boothInitialized) {
+          await initVotingBooth(
+            adminContract,
+            festivalData.chainId,
+            env.HOTSPOT_ADDRESS,
+          );
+        }
+      });
+
+      it('should succeed', async () => {
+        await request(app)
+          .get('/api/hotspot')
+          .expect(httpStatus.OK)
+          .expect((response) => {
+            const { booth, festivalQuestionId } = response.body.data;
+            expect(booth).toBe(env.HOTSPOT_ADDRESS);
+            expect(festivalQuestionId).toBe(
+              parseInt(env.HOTSPOT_FESTIVAL_QUESTION),
+            );
+          });
+      });
+
+      it('should fail when maximum votes are exceeded', async () => {
+        process.env.HOTSPOT_MAX_VOTES = 0;
+        await request(app)
+          .get('/api/hotspot')
+          .expect(httpStatus.UNPROCESSABLE_ENTITY);
+      });
+    });
+
+    //   it('should fail to send vote invitations when unauthorized', async () => {
+    //     await expectNoTasks(queue);
+
+    //     const booth = web3.eth.accounts.create();
+    //     const voteInvitationsData = tasksData.voteInvitation.data.map(
+    //       (invitation) => {
+    //         return {
+    //           ...invitation,
+    //           booth: booth.address,
+    //           boothSignature: web3.eth.accounts.sign(
+    //             packBooth([invitation.festivalAnswerIds], invitation.nonce),
+    //             booth.privateKey,
+    //           ).signature,
+    //         };
+    //       },
+    //     );
+
+    //     await request(app)
+    //       .put('/api/tasks')
+    //       .send({ ...tasksData.voteInvitation, data: voteInvitationsData })
+    //       .expect(httpStatus.UNAUTHORIZED);
+
+    //     await expectNoTasks(queue);
+    //   });
+
+    //   it('should fail with no recipients', async () => {
+    //     const { kind } = tasksData.voteInvitation;
+
+    //     await Promise.all([
+    //       // No recipients.
+    //       authRequest
+    //         .put('/api/tasks')
+    //         .send({ kind, data: [] })
+    //         .expect(httpStatus.BAD_REQUEST),
+    //       // Missing recipients.
+    //       authRequest
+    //         .put('/api/tasks')
+    //         .send({ kind, data: [{ xxx: 'missing to field' }] })
+    //         .expect(httpStatus.BAD_REQUEST),
+    //     ]);
+
+    //     await expectNoTasks(queue);
+    //   });
+    // });
+  });
+});


### PR DESCRIPTION
Adds a new page to the client /hotspot, which queries an api endpoint /api/hotspot to fetch vote data. This page is meant to be run on a local network and be served from inside the gallery, with specially set local env vars. 

It should allow votes up to a pre-determined max votes, for the specified festival. Once voted, a device should not be able to vote again

Here's an example:

```
HOTSPOT_PRIV_KEY=47e7b13e6722242cafff3d13ded1ffdc7f66f777939c1b4924a96545ccada48b
HOTSPOT_ADDRESS=0xdF2d979868B9D99563227Ae89dcb090561fd6c63
HOTSPOT_FESTIVAL_QUESTION=1
HOTSPOT_MAX_VOTES=10
```

Steps to test:
1) set these env vars, and then set up valid data for a vote (a festival with at least one artwork, a festival question, artwork question, etc).
2) go to the booths page, and initialize the HOTSPOT_ADDRESS for the right festival
3) go to `localhost:3000/hotspot` (should be able to successfully vote)
4) refresh the page (should no longer be able to vote)

Closes #110 