### PR TITLE
`isDisabled` is used consistently as prop name across all components

### DIFF
--- a/src/client/components/BoothContainer.js
+++ b/src/client/components/BoothContainer.js
@@ -94,11 +94,11 @@ export const BoothContainerStyle = styled(ContainerStyle)`
   padding: 1rem;
 
   border: 1.5px solid
-    ${(props) => (props.disabled ? styles.colors.gray : styles.colors.violet)};
+    ${(props) => (props.isDisabled ? styles.colors.gray : styles.colors.violet)};
   border-radius: 20px;
 
   color: ${(props) =>
-    props.disabled ? styles.colors.gray : styles.colors.violet};
+    props.isDisabled ? styles.colors.gray : styles.colors.violet};
 `;
 
 const BoothContainerSpinnerStyle = styled.div`

--- a/src/client/components/Button.js
+++ b/src/client/components/Button.js
@@ -5,14 +5,22 @@ import { Link } from 'react-router-dom';
 // eslint-disable-next-line react/display-name
 const Button = React.forwardRef(
   (
-    // eslint-disable-next-line no-unused-vars
-    { children, to, isDanger = false, href, onClick, ...props },
+    {
+      children,
+      to,
+      isDanger = false, // eslint-disable-line no-unused-vars
+      isDisabled: disabled,
+      href,
+      onClick,
+      ...props
+    },
     ref,
   ) => {
     const buttonElem = React.createElement(
       'button',
       Object.assign({}, props, {
         onClick,
+        disabled,
         ref,
       }),
       children,
@@ -31,9 +39,9 @@ const Button = React.forwardRef(
 Button.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
-  disabled: PropTypes.bool,
   href: PropTypes.string,
   isDanger: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
   to: PropTypes.string,
   type: PropTypes.string,

--- a/src/client/components/ButtonClear.js
+++ b/src/client/components/ButtonClear.js
@@ -27,7 +27,7 @@ export const ButtonClearStyle = styled(Button)`
   background-color: transparent;
 
   opacity: ${(props) => {
-    return props.disabled ? '0.3' : '1';
+    return props.isDisabled ? '0.3' : '1';
   }};
 
   cursor: pointer;
@@ -38,8 +38,8 @@ export const ButtonClearStyle = styled(Button)`
 ButtonClear.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
-  disabled: PropTypes.bool,
   isDanger: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
   to: PropTypes.string,
 };

--- a/src/client/components/ButtonIcon.js
+++ b/src/client/components/ButtonIcon.js
@@ -47,7 +47,7 @@ export const ButtonIconStyle = styled(Button)`
   background-color: transparent;
 
   opacity: ${(props) => {
-    return props.disabled ? '0.3' : '1';
+    return props.isDisabled ? '0.3' : '1';
   }};
 
   cursor: pointer;
@@ -87,8 +87,8 @@ export const ButtonIconSVGStyle = styled.div`
 ButtonIcon.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
-  disabled: PropTypes.bool,
   href: PropTypes.string,
+  isDisabled: PropTypes.bool,
   isIconFlipped: PropTypes.bool,
   isIconLeft: PropTypes.bool,
   onClick: PropTypes.func,

--- a/src/client/components/ButtonMore.js
+++ b/src/client/components/ButtonMore.js
@@ -28,7 +28,7 @@ export const ButtonMoreStyle = styled(Button)`
   background-color: transparent;
 
   opacity: ${(props) => {
-    return props.disabled ? '0.3' : '1';
+    return props.isDisabled ? '0.3' : '1';
   }};
 
   cursor: pointer;
@@ -36,7 +36,7 @@ export const ButtonMoreStyle = styled(Button)`
 
 ButtonMore.propTypes = {
   className: PropTypes.string,
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
   to: PropTypes.string,
 };

--- a/src/client/components/ButtonOutline.js
+++ b/src/client/components/ButtonOutline.js
@@ -40,8 +40,8 @@ export const ButtonOutlineStyle = styled(ButtonClearStyle)`
 ButtonOutline.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
-  disabled: PropTypes.bool,
   isDanger: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
   to: PropTypes.string,
 };

--- a/src/client/components/ButtonSubmit.js
+++ b/src/client/components/ButtonSubmit.js
@@ -6,12 +6,12 @@ import { useFormContext } from 'react-form';
 import ButtonIcon from '~/client/components/ButtonIcon';
 import swirl from '~/client/assets/images/swirl.svg';
 
-const ButtonSubmit = ({ children, disabled, ...rest }) => {
+const ButtonSubmit = ({ children, isDisabled, ...rest }) => {
   const { meta } = useFormContext();
 
   return (
     <ButtonIcon
-      disabled={disabled || !meta.canSubmit}
+      isDisabled={isDisabled || !meta.canSubmit}
       type="submit"
       url={swirl}
       {...rest}
@@ -25,7 +25,7 @@ const ButtonSubmit = ({ children, disabled, ...rest }) => {
 
 ButtonSubmit.propTypes = {
   children: PropTypes.node,
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 export default ButtonSubmit;

--- a/src/client/components/ContractsBooths.js
+++ b/src/client/components/ContractsBooths.js
@@ -83,7 +83,7 @@ const ContractsBoothsForm = () => {
         validate={festivalChainIdSchema}
       />
 
-      <ButtonSubmit disabled={meta.request.isPending}>
+      <ButtonSubmit isDisabled={meta.request.isPending}>
         {translate('ContractsBooths.buttonAddNewBooth')}
       </ButtonSubmit>
     </Form>

--- a/src/client/components/ContractsEmailSigner.js
+++ b/src/client/components/ContractsEmailSigner.js
@@ -113,7 +113,7 @@ const ContractsBoothsForm = ({ booth, setFestival }) => {
         onChangeCallback={setFestival}
       />
 
-      <ButtonSubmit disabled={meta.request.isPending}>
+      <ButtonSubmit isDisabled={meta.request.isPending}>
         {translate('ContractsEmailSigner.buttonAddNewBooth')}
       </ButtonSubmit>
     </Form>

--- a/src/client/components/ContractsOwners.js
+++ b/src/client/components/ContractsOwners.js
@@ -127,7 +127,7 @@ const ContractsOwnersForm = () => {
         validate={ownerAddressSchema}
       />
 
-      <ButtonSubmit disabled={meta.request.isPending}>
+      <ButtonSubmit isDisabled={meta.request.isPending}>
         {translate('ContractsOwners.buttonAddNewOwner')}
       </ButtonSubmit>
     </Form>
@@ -160,7 +160,7 @@ const ContractsOwnersListItem = ({ isDisabled, ownerAddress, onRemove }) => {
     <ContractsOwnersItemStyle>
       <ContractsOwnersAddressStyle>{ownerAddress}</ContractsOwnersAddressStyle>
 
-      <ButtonOutline disabled={isDisabled} onClick={onClickRemove}>
+      <ButtonOutline isDisabled={isDisabled} onClick={onClickRemove}>
         {translate('ContractsOwners.buttonRemoveOwner')}
       </ButtonOutline>
     </ContractsOwnersItemStyle>

--- a/src/client/components/EthereumContainer.js
+++ b/src/client/components/EthereumContainer.js
@@ -26,7 +26,7 @@ const EthereumContainer = (props) => {
   };
 
   return (
-    <EthereumContainerStyle disabled={!hasProvider}>
+    <EthereumContainerStyle isDisabled={!hasProvider}>
       <HeadingSecondaryStyle>
         {translate('EthereumContainer.title')}
       </HeadingSecondaryStyle>
@@ -86,11 +86,11 @@ export const EthereumContainerStyle = styled.section`
   padding: 1rem;
 
   border: 1.5px solid
-    ${(props) => (props.disabled ? styles.colors.gray : styles.colors.violet)};
+    ${(props) => (props.isDisabled ? styles.colors.gray : styles.colors.violet)};
   border-radius: 20px;
 
   color: ${(props) =>
-    props.disabled ? styles.colors.gray : styles.colors.violet};
+    props.isDisabled ? styles.colors.gray : styles.colors.violet};
 `;
 
 const EthereumContainerSpinnerStyle = styled.div`

--- a/src/client/components/ExportVotesContainer.js
+++ b/src/client/components/ExportVotesContainer.js
@@ -57,7 +57,7 @@ const ExportVotesContainer = ({ name, path }) => {
         {translate('ExportVotesContainer.title')}
       </HeadingSecondaryStyle>
 
-      <ButtonIcon disabled={isLoading} url={swirl} onClick={getVotesCsv}>
+      <ButtonIcon isDisabled={isLoading} url={swirl} onClick={getVotesCsv}>
         {translate('ExportVotesContainer.buttonDownload')}
       </ButtonIcon>
     </VoteweightsContainerStyle>
@@ -72,11 +72,11 @@ export const VoteweightsContainerStyle = styled.section`
   padding: 1rem;
 
   border: 1.5px solid
-    ${(props) => (props.disabled ? styles.colors.gray : styles.colors.violet)};
+    ${(props) => (props.isDisabled ? styles.colors.gray : styles.colors.violet)};
   border-radius: 20px;
 
   color: ${(props) =>
-    props.disabled ? styles.colors.gray : styles.colors.violet};
+    props.isDisabled ? styles.colors.gray : styles.colors.violet};
 `;
 
 ExportVotesContainer.propTypes = {

--- a/src/client/components/FestivalQuestionsContainer.js
+++ b/src/client/components/FestivalQuestionsContainer.js
@@ -73,11 +73,11 @@ export const QuestionsContainerStyle = styled.section`
   padding: 1rem;
 
   border: 1.5px solid
-    ${(props) => (props.disabled ? styles.colors.gray : styles.colors.violet)};
+    ${(props) => (props.isDisabled ? styles.colors.gray : styles.colors.violet)};
   border-radius: 20px;
 
   color: ${(props) =>
-    props.disabled ? styles.colors.gray : styles.colors.violet};
+    props.isDisabled ? styles.colors.gray : styles.colors.violet};
 `;
 
 FestivalQuestionsContainer.propTypes = {

--- a/src/client/components/FileUpload.js
+++ b/src/client/components/FileUpload.js
@@ -13,7 +13,7 @@ const DEFAULT_UPLOAD_TEXT =
 const FileUpload = ({
   onUpload,
   onError,
-  disabled = false,
+  isDisabled = false,
   accept = [],
   uploadText = DEFAULT_UPLOAD_TEXT,
 }) => {
@@ -45,7 +45,7 @@ const FileUpload = ({
   return (
     <DropZone
       accept={accept}
-      disabled={disabled}
+      disabled={isDisabled}
       multiple={false}
       onDrop={onDrop}
     >
@@ -54,8 +54,8 @@ const FileUpload = ({
           <input {...getInputProps()} />
 
           <FileUploadStyle
-            disabled={disabled}
             isAlternateColor={isAlternateColor}
+            isDisabled={isDisabled}
           >
             {isDragActive ? <p>Drop your file here</p> : <p>{uploadText}</p>}
           </FileUploadStyle>
@@ -67,7 +67,7 @@ const FileUpload = ({
 
 FileUpload.propTypes = {
   accept: PropTypes.arrayOf(PropTypes.string),
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onError: PropTypes.func.isRequired,
   onUpload: PropTypes.func.isRequired,
   uploadText: PropTypes.string,
@@ -94,7 +94,7 @@ export const FileUploadStyle = styled.div`
 
   text-overflow: ellipsis;
 
-  opacity: ${(props) => (props.disabled ? 0.2 : 1)};
+  opacity: ${(props) => (props.isDisabled ? 0.2 : 1)};
 
   text-align: center;
 `;

--- a/src/client/components/FormAnswers.js
+++ b/src/client/components/FormAnswers.js
@@ -76,7 +76,7 @@ const FormAnswers = ({ question, festivalId, isDisabled }) => {
       {question.type === 'festival' ? (
         <InputFinderField
           clientSideFilter={filter}
-          disabled={isDisabled}
+          isDisabled={isDisabled}
           label={translate('AdminAnswersNew.fieldArtwork')}
           name="artworkId"
           placeholder={translate('AdminAnswersNew.fieldArtworkPlaceholder')}

--- a/src/client/components/FormQuestions.js
+++ b/src/client/components/FormQuestions.js
@@ -51,7 +51,7 @@ const FormQuestions = ({
 
       {showFestivalFinder && (
         <InputFinderField
-          disabled={isFestivalDisabled}
+          isDisabled={isFestivalDisabled}
           label={translate('FormQuestions.fieldFestival')}
           name="festivalId"
           placeholder={translate('FormQuestions.fieldFestivalPlaceholder')}
@@ -64,7 +64,7 @@ const FormQuestions = ({
       {showArtworkFinder && (
         <InputFinderField
           clientSideFilter={filter}
-          disabled={!hasFestival || isArtworkDisabled}
+          isDisabled={!hasFestival || isArtworkDisabled}
           label={translate('FormQuestions.fieldArtwork')}
           name="artworkId"
           placeholder={translate('FormQuestions.fieldArtworkPlaceholder')}

--- a/src/client/components/FormScheduleEmail.js
+++ b/src/client/components/FormScheduleEmail.js
@@ -14,11 +14,11 @@ export const schema = {
     .required(),
 };
 
-const FormScheduleEmail = ({ disabled = false }) => {
+const FormScheduleEmail = ({ isDisabled = false }) => {
   return (
     <Fragment>
       <InputTextareaField
-        disabled={disabled}
+        isDisabled={isDisabled}
         label={translate('FormScheduleEmail.fieldRecipients')}
         name="recipients"
         rows={15}
@@ -29,7 +29,7 @@ const FormScheduleEmail = ({ disabled = false }) => {
 };
 
 FormScheduleEmail.propTypes = {
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 export default FormScheduleEmail;

--- a/src/client/components/FormVoteweights.js
+++ b/src/client/components/FormVoteweights.js
@@ -90,7 +90,7 @@ const FormVoteweights = ({
       />
 
       <InputSelectField
-        disabled={isDisabled}
+        isDisabled={isDisabled}
         label={translate('FormVoteweights.fieldType')}
         name="type"
         validate={schema.type}

--- a/src/client/components/InputArtworksField.js
+++ b/src/client/components/InputArtworksField.js
@@ -66,7 +66,7 @@ const InputArtworksFieldItems = ({ artworks, onRemove }) => {
               {artwork.title}
             </InputArtworksFieldItemTextStyle>
 
-            <ButtonOutline disabled={!artwork.id} onClick={onClickRemove}>
+            <ButtonOutline isDisabled={!artwork.id} onClick={onClickRemove}>
               {translate('InputUploadField.buttonRemoveFile')}
             </ButtonOutline>
           </InputArtworksFieldItemStyle>

--- a/src/client/components/InputField.js
+++ b/src/client/components/InputField.js
@@ -8,13 +8,14 @@ import styles from '~/client/styles/variables';
 
 // eslint-disable-next-line react/display-name
 const InputField = React.forwardRef(
-  ({ name, validate, label, ...rest }, ref) => {
+  ({ name, validate, label, isDisabled, ...rest }, ref) => {
     const { meta, getInputProps } = useField(name, { validate });
 
     return (
       <InputFieldset label={label} meta={meta} name={name}>
         <InputFieldStyle
           {...getInputProps({ ref, id: name, ...rest })}
+          disabled={isDisabled}
           ref={ref}
         />
       </InputFieldset>
@@ -38,6 +39,7 @@ export const InputFieldStyle = styled.input`
 `;
 
 InputField.propTypes = {
+  isDisabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   validate: PropTypes.object.isRequired,

--- a/src/client/components/InputSelectField.js
+++ b/src/client/components/InputSelectField.js
@@ -8,13 +8,14 @@ import styles from '~/client/styles/variables';
 
 // eslint-disable-next-line react/display-name
 const InputSelectField = React.forwardRef(
-  ({ name, validate, label, children, ...rest }, ref) => {
+  ({ name, validate, isDisabled, label, children, ...rest }, ref) => {
     const { meta, getInputProps } = useField(name, { validate });
     return (
       <InputFieldset label={label} meta={meta} name={name}>
         <InputSelectFieldStyle>
           <InputSelectFieldInnerStyle
             {...getInputProps({ ref, id: name, ...rest })}
+            disabled={isDisabled}
             ref={ref}
           >
             {children}
@@ -65,6 +66,7 @@ export const InputSelectFieldInnerStyle = styled.select`
 
 InputSelectField.propTypes = {
   children: PropTypes.node.isRequired,
+  isDisabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   validate: PropTypes.object.isRequired,

--- a/src/client/components/InputTextareaField.js
+++ b/src/client/components/InputTextareaField.js
@@ -8,12 +8,13 @@ import { useField } from '~/client/hooks/forms';
 
 // eslint-disable-next-line react/display-name
 const InputTextareaField = React.forwardRef(
-  ({ name, validate, label, value, ...rest }, ref) => {
+  ({ name, validate, label, value, isDisabled, ...rest }, ref) => {
     const { meta, getInputProps } = useField(name, { validate });
     return (
       <InputFieldset label={label} meta={meta} name={name}>
         <InputTextareaFieldStyle
           {...getInputProps({ ref, id: name, ...rest })}
+          disabled={isDisabled}
           ref={ref}
         >
           {value}
@@ -41,6 +42,7 @@ export const InputTextareaFieldStyle = styled.textarea`
 `;
 
 InputTextareaField.propTypes = {
+  isDisabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   validate: PropTypes.object.isRequired,

--- a/src/client/components/InputUploadField.js
+++ b/src/client/components/InputUploadField.js
@@ -202,7 +202,7 @@ const InputUploadField = ({
         onChange={onChangeFiles}
       />
 
-      <ButtonOutline disabled={isPending} onClick={onClickUpload}>
+      <ButtonOutline isDisabled={isPending} onClick={onClickUpload}>
         {translate('InputUploadField.buttonSelectFiles')}
       </ButtonOutline>
     </InputFieldsetRounded>
@@ -230,7 +230,7 @@ const InputUploadFieldItems = ({ files, onRemove }) => {
               [{fileType}]
             </InputUploadFieldItemTextStyle>
 
-            <ButtonOutline disabled={!id} onClick={onClickRemove}>
+            <ButtonOutline isDisabled={!id} onClick={onClickRemove}>
               {translate('InputUploadField.buttonRemoveFile')}
             </ButtonOutline>
           </InputUploadFieldItemStyle>

--- a/src/client/components/Table.js
+++ b/src/client/components/Table.js
@@ -403,13 +403,13 @@ export const TableFooter = ({
       <tr>
         <td colSpan={colSpan}>
           <ButtonOutline
-            disabled={isPreviousDisabled}
+            isDisabled={isPreviousDisabled}
             onClick={onClickPrevious}
           >
             &lt;
           </ButtonOutline>
 
-          <ButtonOutline disabled={isNextDisabled} onClick={onClickNext}>
+          <ButtonOutline isDisabled={isNextDisabled} onClick={onClickNext}>
             &gt;
           </ButtonOutline>
         </td>

--- a/src/client/components/VoteSession.js
+++ b/src/client/components/VoteSession.js
@@ -446,7 +446,7 @@ const VoteSession = ({
 
                     <PaperTicket>
                       <ButtonIcon
-                        disabled={!winnerArtworkId}
+                        isDisabled={!winnerArtworkId}
                         onClick={onNextStep}
                       >
                         {translate('VoteSession.buttonNextStep')}
@@ -491,7 +491,7 @@ const VoteSession = ({
                           </ButtonIcon>
 
                           <ButtonIcon
-                            disabled={!hasVotedOnArtworks}
+                            isDisabled={!hasVotedOnArtworks}
                             onClick={onVote}
                           >
                             {translate('VoteSession.buttonVote')}

--- a/src/client/components/VoteSessionCreator.js
+++ b/src/client/components/VoteSessionCreator.js
@@ -277,7 +277,7 @@ const VoteSessionCreator = () => {
 
             <SpacingGroupStyle>
               <ButtonIcon
-                disabled={isManual}
+                isDisabled={isManual}
                 url={rectangle}
                 onClick={onManualOverride}
               >
@@ -285,7 +285,7 @@ const VoteSessionCreator = () => {
               </ButtonIcon>
 
               <ButtonIcon
-                disabled={
+                isDisabled={
                   isVotePending ||
                   festivalAnswerIds.length === 0 ||
                   isVoteCreated
@@ -296,7 +296,7 @@ const VoteSessionCreator = () => {
               </ButtonIcon>
 
               <ButtonIcon
-                disabled={festivalAnswerIds.length === 0}
+                isDisabled={festivalAnswerIds.length === 0}
                 url={swirl}
                 onClick={onReset}
               >

--- a/src/client/components/VoteweightsContainer.js
+++ b/src/client/components/VoteweightsContainer.js
@@ -78,11 +78,11 @@ export const VoteweightsContainerStyle = styled.section`
   padding: 1rem;
 
   border: 1.5px solid
-    ${(props) => (props.disabled ? styles.colors.gray : styles.colors.violet)};
+    ${(props) => (props.isDisabled ? styles.colors.gray : styles.colors.violet)};
   border-radius: 20px;
 
   color: ${(props) =>
-    props.disabled ? styles.colors.gray : styles.colors.violet};
+    props.isDisabled ? styles.colors.gray : styles.colors.violet};
 `;
 
 VoteweightsContainer.propTypes = {

--- a/src/client/hooks/forms.js
+++ b/src/client/hooks/forms.js
@@ -231,7 +231,7 @@ export const useEditForm = ({
 
   const ButtonDelete = () => {
     return (
-      <ButtonOutline disabled={!canSubmit} isDanger onClick={onClickDestroy}>
+      <ButtonOutline isDanger isDisabled={!canSubmit} onClick={onClickDestroy}>
         {translate('default.buttonDestroy')}
       </ButtonOutline>
     );

--- a/src/client/views/AdminEmails.js
+++ b/src/client/views/AdminEmails.js
@@ -248,16 +248,16 @@ const AdminEmails = () => {
             selectParam={'id'}
             validate={organisationSchema}
           />
-          <FormScheduleEmail disabled={!isReadyToSign} />
+          <FormScheduleEmail isDisabled={!isReadyToSign} />
 
           <FileUpload
             accept={['text/plain', 'text/csv', 'text/x-csv']}
-            disabled={!isReadyToSign}
+            isDisabled={!isReadyToSign}
             uploadText={translate('AdminEmails.fileUpload')}
             onError={handleFileUploadError}
             onUpload={handleFileUpload}
           />
-          <ButtonSubmit disabled={!isValid && !isLoading} />
+          <ButtonSubmit isDisabled={!isValid && !isLoading} />
         </Form>
       </ViewAdmin>
 


### PR DESCRIPTION
We had a mix of `disabled` and `isDisabled` as prop name. The latter
mostly being used for our own components and the former being used for
form elements. But his line even blurred at times, e.g. the
`InputFinderField` used `isDisabled` while the `FileUpload` and
`FormScheduleEmail` components used `disabled` as prop name.

All components were refactored to use `isDisabled` as prop name (which
would be more like idiomatic JavaScript) and is in line with other
boolean prop fields that we use (e.g. `isDanger` or `isVisible`). For
components that wrap directly a form element (e.g. `Button` or
`InputField`) map `isDisabled` to `disabled` accordingly.

closes #180