### PR TITLE
Fix the creation of inline questions

### DIFF
--- a/src/client/components/FormQuestions.js
+++ b/src/client/components/FormQuestions.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 
 import InputField from '~/client/components/InputField';
+import InputHiddenField from '~/client/components/InputHiddenField';
 import InputFinderField from '~/client/components/InputFinderField';
 import translate from '~/common/services/i18n';
 import { QUESTION_TYPES } from '~/common/helpers/validate';
@@ -49,7 +50,7 @@ const FormQuestions = ({
         validate={schema.title}
       />
 
-      {showFestivalFinder && (
+      {showFestivalFinder ? (
         <InputFinderField
           isDisabled={isFestivalDisabled}
           label={translate('FormQuestions.fieldFestival')}
@@ -59,6 +60,8 @@ const FormQuestions = ({
           searchParam={'title'}
           validate={schema.festivalId}
         />
+      ) : (
+        <InputHiddenField name="festivalId" value={{ value: festivalId }} />
       )}
 
       {showArtworkFinder && (


### PR DESCRIPTION
Not sure how it slipped but creating new questions inline of festivals
didn't work. The issue was that the `festivalId` wasn't set and
therefore failed schema validation server side when making the PUT
request. This is an easy fix by setting the `festivalId` as an hidden
input field. This makes sure that the field is included in the HTTP
request.