### PR TITLE
Move transaction processing into the worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "backend:start": "concurrently --prefix '{pid}-{name}' --names 'API,WORKERS' --kill-others 'npm run server:start' 'npm run worker:start'",
     "backend:watch": "concurrently --prefix '{pid}-{name}' --names 'API,WORKERS' --kill-others 'npm run server:watch' 'npm run worker:watch'",
     "worker:serve": "NODE_ENV=development babel-node -r dotenv/config ./src/server/worker.js --source-maps inline",
-    "worker:start": "cross-env NODE_ENV=production node ./build/server/worker.js",
-    "worker:watch": "nodemon --watch ./src --exec npm run worker:serve"
+    "worker:start": "cross-env NODE_ENV=production node WORKER=true ./build/server/worker.js",
+    "worker:watch": "WORKER=true nodemon --watch ./src --exec npm run worker:serve"
   },
   "repository": {
     "type": "git",

--- a/src/server/services/dispatcher.js
+++ b/src/server/services/dispatcher.js
@@ -27,8 +27,8 @@ export default async function dispatchVote({
 
   const from = payer.address;
   const to = questionAddress;
-  const txNonce = await web3.eth.getTransactionCount(payer.address);
   const gas = await web3.eth.estimateGas({ to, data, from: payer.address });
+  const txNonce = await web3.eth.getTransactionCount(payer.address);
 
   const signed = await web3.eth.accounts.signTransaction(
     {

--- a/src/server/tasks/index.js
+++ b/src/server/tasks/index.js
@@ -1,9 +1,11 @@
 import cleanup from '~/server/tasks/cleanup';
 import mailing from '~/server/tasks/sendmail';
+import sendTransaction from '~/server/tasks/sendTransaction';
 
-export const allTasks = [cleanup, mailing];
+export const allTasks = [cleanup, mailing, sendTransaction];
 
 export default {
   cleanup,
   mailing,
+  sendTransaction,
 };

--- a/src/server/tasks/processor.js
+++ b/src/server/tasks/processor.js
@@ -1,47 +1,50 @@
 import logger from '~/server/helpers/logger';
 
 export default function processor(queue) {
-  queue.on('error', (error) => {
-    logger.error(`ERROR "${queue.name}" job: ${error}`);
+  if (process.env.WORKER) {
+    queue.on('error', (error) => {
+      logger.error(`ERROR "${queue.name}" job: ${error}`);
 
-    // eslint-disable-next-line
-    console.error(error);
-  });
+      // eslint-disable-next-line
+      console.error(error);
+    });
 
-  queue.on('active', (job) => {
-    logger.info(`[${job.id}] ACTIVE "${queue.name}" job started`);
-  });
+    queue.on('active', (job) => {
+      logger.info(`[${job.id}] ACTIVE "${queue.name}" job started`);
+    });
 
-  queue.on('progress', (job, progress) => {
-    logger.info(`[${job.id}]" PROGRESS ${queue.name}" job: ${progress}`);
-  });
+    queue.on('progress', (job, progress) => {
+      logger.info(`[${job.id}]" PROGRESS ${queue.name}" job: ${progress}`);
+    });
 
-  queue.on('completed', (job) => {
-    logger.info(`[${job.id}] COMPLETE "${queue.name}" job`);
-  });
+    queue.on('completed', (job) => {
+      logger.info(`[${job.id}] COMPLETE "${queue.name}" job`);
+    });
 
-  queue.on('failed', (job, error) => {
-    logger.warn(`[${job.id}] FAILED "${queue.name}": ${error}`);
+    queue.on('failed', (job, error) => {
+      logger.warn(`[${job.id}] FAILED "${queue.name}": ${error}`);
 
-    // eslint-disable-next-line
-    console.error(error);
-  });
+      // eslint-disable-next-line
+      console.error(error);
+    });
 
-  queue.on('stalled', (job) => {
-    logger.info(`[${job.id}] STALLED "${queue.name}"`);
-  });
+    queue.on('stalled', (job) => {
+      logger.info(`[${job.id}] STALLED "${queue.name}"`);
+    });
 
-  queue.on('cleaned', (jobs, type) => {
-    logger.info(`"${queue.name}" cleaned ${type} ${jobs.length}`);
-  });
+    queue.on('cleaned', (jobs, type) => {
+      logger.info(`"${queue.name}" cleaned ${type} ${jobs.length}`);
+    });
 
-  queue.on('paused', () => {
-    logger.info(`"${queue.name}" queue paused`);
-  });
+    queue.on('paused', () => {
+      logger.info(`"${queue.name}" queue paused`);
+    });
 
-  queue.on('resumed', () => {
-    logger.info(`"${queue.name}" queue resumed`);
-  });
+    queue.on('resumed', () => {
+      logger.info(`"${queue.name}" queue resumed`);
+    });
 
-  return queue;
+    return queue;
+  }
+  return { process: () => {} };
 }

--- a/src/server/tasks/sendTransaction.js
+++ b/src/server/tasks/sendTransaction.js
@@ -1,0 +1,33 @@
+import Queue from 'bull';
+
+import processor from '~/server/tasks/processor';
+import { redisUrl, redisLongRunningOptions } from '~/server/services/redis';
+import submitJob from '~/server/tasks/submitJob';
+import dispatchVote from '~/server/services/dispatcher';
+import logger from '~/server/helpers/logger';
+
+const transactions = new Queue('Send transactions', redisUrl, {
+  settings: redisLongRunningOptions,
+});
+
+processor(transactions).process(1, async ({ data }) => {
+  try {
+    const tx = await dispatchVote(data);
+    logger.info(
+      `Finished processing vote with transaction hash ${tx.transactionHash}`,
+    );
+  } catch (error) {
+    logger.error(error);
+    throw error;
+  }
+});
+
+export const sendVoteTransaction = (data) => {
+  submitJob(
+    transactions,
+    `${data.boothAddress}#${data.nonce}#${data.questionAddress}`,
+    data,
+  );
+};
+
+export default transactions;


### PR DESCRIPTION
Instead of directly processing transactions, this pr moves transaction sending into a task processed by the worker. It also restricts concurrency to 1 for transaction sending jobs

The api is unchanged, so testing should just be the normal vote flow

Closes #20