### PR TITLE
Deleting questions

### DIFF
--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -16,7 +16,7 @@ import {
   stickerValidation,
 } from '~/common/helpers/validate';
 
-const FormFestivals = ({ questionId }) => {
+const FormFestivals = ({ hasQuestion, editing }) => {
   const schema = {
     artworks: Joi.array().required().max(30),
     description: Joi.string().max(2000).required(),
@@ -68,7 +68,7 @@ const FormFestivals = ({ questionId }) => {
         validate={schema.online}
       />
 
-      {questionId ? null : (
+      {!hasQuestion && editing ? null : (
         <>
           <InputField
             label={translate('FormFestivals.fieldQuestion')}
@@ -119,8 +119,8 @@ const FormFestivals = ({ questionId }) => {
 };
 
 FormFestivals.propTypes = {
-  isPasswordHidden: PropTypes.bool,
-  questionId: PropTypes.number,
+  editing: PropTypes.bool,
+  hasQuestion: PropTypes.bool,
 };
 
 export default FormFestivals;

--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -16,7 +16,7 @@ import {
   stickerValidation,
 } from '~/common/helpers/validate';
 
-const FormFestivals = ({ hasQuestion, editing }) => {
+const FormFestivals = ({ editing }) => {
   const schema = {
     artworks: Joi.array().required().max(30),
     description: Joi.string().max(2000).required(),
@@ -68,7 +68,7 @@ const FormFestivals = ({ hasQuestion, editing }) => {
         validate={schema.online}
       />
 
-      {!hasQuestion && editing ? null : (
+      {editing ? null : (
         <>
           <InputField
             label={translate('FormFestivals.fieldQuestion')}

--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -16,7 +16,7 @@ import {
   stickerValidation,
 } from '~/common/helpers/validate';
 
-const FormFestivals = ({ editing }) => {
+const FormFestivals = ({ hasQuestion, editing }) => {
   const schema = {
     artworks: Joi.array().required().max(30),
     description: Joi.string().max(2000).required(),
@@ -68,9 +68,10 @@ const FormFestivals = ({ editing }) => {
         validate={schema.online}
       />
 
-      {editing ? null : (
+      {!hasQuestion && editing ? null : (
         <>
           <InputField
+            isDisabled={editing}
             label={translate('FormFestivals.fieldQuestion')}
             name="question.title"
             type="text"

--- a/src/client/components/FormQuestions.js
+++ b/src/client/components/FormQuestions.js
@@ -21,12 +21,11 @@ const FormQuestions = ({
       .integer()
       .required()
       .error(new Error(translate('validations.festivalRequired'))),
-    artworkId: showArtworkFinder
-      ? Joi.number()
-          .integer()
-          .required()
-          .error(new Error(translate('validations.artworkRequired')))
-      : Joi.number().integer().allow(null),
+    artworkId: Joi.alternatives().conditional('type', {
+      is: 'festival',
+      then: Joi.number().allow(null),
+      otherwise: Joi.number().integer().required(),
+    }),
     // the question type is set by the caller of FormQuestions
     type: Joi.valid(...QUESTION_TYPES).required(),
   };

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -87,10 +87,7 @@ const AdminFestivalsEditForm = () => {
     <Fragment>
       <ViewAdmin>
         <Form>
-          <FormFestivals
-            editing={true}
-            hasQuestion={resource.question ? true : false}
-          />
+          <FormFestivals editing={true} />
 
           {!isResourceLoading && (
             <FestivalQuestionsContainer festivalId={resource.id} />

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -87,7 +87,12 @@ const AdminFestivalsEditForm = () => {
     <Fragment>
       <ViewAdmin>
         <Form>
-          <FormFestivals editing={true} />
+          <FormFestivals
+            editing={true}
+            hasQuestion={
+              resource.question && resource.question.id ? true : false
+            }
+          />
 
           {!isResourceLoading && (
             <FestivalQuestionsContainer festivalId={resource.id} />

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -87,7 +87,10 @@ const AdminFestivalsEditForm = () => {
     <Fragment>
       <ViewAdmin>
         <Form>
-          <FormFestivals questionId={resource?.question?.id} />
+          <FormFestivals
+            editing={true}
+            hasQuestion={resource.question ? true : false}
+          />
 
           {!isResourceLoading && (
             <FestivalQuestionsContainer festivalId={resource.id} />

--- a/src/client/views/AdminQuestionsNew.js
+++ b/src/client/views/AdminQuestionsNew.js
@@ -46,13 +46,13 @@ const AdminQuestionsNew = () => {
   });
 
   // Artworks are chosen based on the festival. When selecting a new festival we
-  // want to invalidate the select artwork since a different festival has
+  // want to invalidate the selected artwork since a different festival has
   // different artworks to choose from. To achieve this I cache the selected
   // festivalId and forcefully invalidate the artworkId if it changes.
   useEffect(() => {
     if (festivalId != festivalIdCache) {
       setFestivalIdCache(festivalId);
-      setValues({ title, festivalId, type: 'festival', artworkId: undefined });
+      setValues({ title, festivalId, type: 'festival', artworkId: null });
     }
   }, [setValues, title, festivalId, type, festivalIdCache]);
 
@@ -64,6 +64,8 @@ const AdminQuestionsNew = () => {
       artworkId,
       type: artworkId == null ? 'festival' : 'artwork',
     });
+    console.log(artworkId) // eslint-disable-line
+    console.log(type) // eslint-disable-line
   }, [setValues, title, festivalId, artworkId]);
 
   return (

--- a/src/client/views/AdminQuestionsNew.js
+++ b/src/client/views/AdminQuestionsNew.js
@@ -52,7 +52,7 @@ const AdminQuestionsNew = () => {
   useEffect(() => {
     if (festivalId != festivalIdCache) {
       setFestivalIdCache(festivalId);
-      setValues({ title, festivalId, type: 'festival', artworkId: null });
+      setValues({ title, festivalId, type: 'festival', artworkId: undefined });
     }
   }, [setValues, title, festivalId, type, festivalIdCache]);
 
@@ -64,8 +64,6 @@ const AdminQuestionsNew = () => {
       artworkId,
       type: artworkId == null ? 'festival' : 'artwork',
     });
-    console.log(artworkId) // eslint-disable-line
-    console.log(type) // eslint-disable-line
   }, [setValues, title, festivalId, artworkId]);
 
   return (

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -267,7 +267,7 @@ function readAll(options) {
 function read(options) {
   return async (req, res, next) => {
     try {
-      let instance = await options.model.findOne({
+      const instance = await options.model.findOne({
         rejectOnEmpty: true,
         where: {
           id: req.locals.resource.id,

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -267,7 +267,7 @@ function readAll(options) {
 function read(options) {
   return async (req, res, next) => {
     try {
-      const instance = await options.model.findOne({
+      let instance = await options.model.findOne({
         rejectOnEmpty: true,
         where: {
           id: req.locals.resource.id,
@@ -280,6 +280,16 @@ function read(options) {
         : filterResponseFields;
 
       const filteredResults = filter(req, instance, options);
+
+      if (options.manuallyAppend) {
+        Object.keys(options.manuallyAppend).map((key) => {
+          filteredResults[key] = filterResponseFields(
+            req,
+            options.manuallyAppend[key].data,
+            { fields: options.manuallyAppend[key].fields },
+          );
+        });
+      }
 
       respondWithSuccess(res, filteredResults);
     } catch (error) {


### PR DESCRIPTION
So I started off thinking "Oh I'll just handle the thing where the festival page won't load when you delete a festival-question and make the artworkId not required for festival questions" .... but then I turned up the bug where the festival page displays the wrong question again, when there are multiple questions. I thought we had fixed this one, but I guess not! I feel like it's my fault for not reviewing more thoroughly!

Unfortunately I think that bug might be an unavoidable side-effect of using FestivalHasOneQuestion to represent what is fundamentally a one-to-many relationship, so I added a function to manually find the festival question instead of using the associations (the new function fails if there is no festival-question, or more than one festival-question). Because this isn't using the association anymore, it also breaks inline-question editing. I considered getting that working again, but decided it was probably a lengthy task, that might not be worth it, since there's an edit button below in the table?  I took the route of disabling the Question field on the FestivalEdit view. Questions can still be updated on the QuestionsEdit view. Also glad I looked into this, because question fields weren't being filtered properly when queried via a festival! So this should also be working now :crossed_fingers: 

To test:
1. Create multiple festivals, each with a festival question, and an artwork question
2. Verify that the right question is displayed inline on the festival, and is disabled on the edit page
3. Try deleting and re-creating questions, verify that the FestivalEdit page loads after deleting and also after re-creating

Closes #187 