### PR TITLE
Add thank you link to the final vote screen if present

### DIFF
--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -27,6 +27,7 @@ const FormFestivals = ({ questionId }) => {
     subtitle: Joi.string().max(255).required(),
     title: Joi.string().max(128).required(),
     url: Joi.string().uri().allow(''),
+    thankyouUrl: Joi.string().uri().allow(''),
     question: {
       title: Joi.string().max(128).required(),
       type: Joi.valid('festival').required(),
@@ -54,6 +55,13 @@ const FormFestivals = ({ questionId }) => {
         name="url"
         type="text"
         validate={schema.url}
+      />
+
+      <InputField
+        label={translate('FormFestivals.fieldThankyouUrl')}
+        name="thankyouUrl"
+        type="text"
+        validate={schema.thankyouUrl}
       />
 
       <InputTextareaField

--- a/src/client/components/VoteSession.js
+++ b/src/client/components/VoteSession.js
@@ -398,6 +398,12 @@ const VoteSession = ({
               <HorizontalLine />
 
               <ButtonGroup>
+                {data.thankyouUrl ? (
+                  <ButtonIcon href={data.thankyouUrl}>
+                    {translate('VoteSession.buttonThankyou')}
+                  </ButtonIcon>
+                ) : null}
+
                 <ButtonIcon to={`/festivals/${data.slug}`}>
                   {translate('VoteSession.buttonVoteResults')}
                 </ButtonIcon>

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -45,6 +45,7 @@ const AdminFestivalsEditForm = () => {
       'subtitle',
       'title',
       'url',
+      'thankyouUrl',
     ],
     resourcePath: ['festivals', slug],
     returnUrl,

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -104,6 +104,7 @@ const components = {
     fieldQuestion: 'Question:',
     fieldArtworks: 'Artworks:',
     fieldUrl: 'Website:',
+    fieldThankyouUrl: 'Custom thank you link:',
     buttonEditQuestion: 'Manage',
   },
   FormScheduleEmail: {
@@ -239,6 +240,7 @@ const components = {
     buttonNextStep: 'Next',
     buttonPreviousStep: 'Return',
     buttonVoteResults: 'View the vote results so far',
+    buttonThankyou: 'Click here to try on our thank you instagram filter!',
     buttonToHomepage: 'Back to Homepage',
     buttonVote: 'Vote',
     errorVoteFailure: 'Your vote was not accepted .. did you already vote?',

--- a/src/server/database/associations.js
+++ b/src/server/database/associations.js
@@ -43,6 +43,7 @@ export const festivalFields = [
   'title',
   'url',
   'online',
+  'thankyouUrl',
 ];
 export const invitationFields = [
   'boothSignature',

--- a/src/server/database/migrations/20210410132209-add-thank-you-link.js
+++ b/src/server/database/migrations/20210410132209-add-thank-you-link.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('festivals', 'thankyouUrl', {
+      type: Sequelize.STRING,
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.removeColumn('festivals', 'thankyouUrl');
+  },
+};

--- a/src/server/models/festival.js
+++ b/src/server/models/festival.js
@@ -50,6 +50,9 @@ const Festival = db.define('festival', {
   url: {
     type: DataTypes.STRING,
   },
+  thankyouUrl: {
+    type: DataTypes.STRING,
+  },
 });
 
 SequelizeSlugify.slugifyModel(Festival, {

--- a/src/server/validations/festivals.js
+++ b/src/server/validations/festivals.js
@@ -19,6 +19,7 @@ const defaultValidation = {
   subtitle: Joi.string().max(255).required(),
   title: Joi.string().max(128).required(),
   url: Joi.string().uri().allow(''),
+  thankyouUrl: Joi.string().uri().allow(''),
 };
 
 const createValidation = {


### PR DESCRIPTION
This adds a new optional field to festivals for a thank you link. Furtherfield is going to use this link to direct people to a custom instagram filter that says they voted. If the link is present, a button is displayed on the "Thank you for voting" page that directs people to the thank you link.

To test:
1. Set up a festival with everything you need for voting, and set thank you link
2. Vote, and verify that there is a new button that directs to the thank you link
3. Delete the thank you link from the festival
4. Vote again, and verify that the button is not displayed

Closes #195 