### PR TITLE
Add festival link to the vote page for online festivals

### DIFF
--- a/src/client/components/VoteSession.js
+++ b/src/client/components/VoteSession.js
@@ -433,6 +433,17 @@ const VoteSession = ({
                           {festivalQuestionData.title}
                         </HeadingPrimaryStyle>
                       </BoxFramed>
+                      {data.online ? (
+                        <Fragment>
+                          <HorizontalSpacingStyle />
+                          <ParagraphStyle>
+                            {translate('VoteSession.festivalLinkPrompt')}
+                          </ParagraphStyle>
+                          <ButtonIcon href={data.url}>
+                            {translate('VoteSession.buttonFestivalLink')}
+                          </ButtonIcon>
+                        </Fragment>
+                      ) : null}
                     </PaperTicket>
 
                     {artworks.map((artwork) => {

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -240,8 +240,10 @@ const components = {
     buttonPreviousStep: 'Return',
     buttonVoteResults: 'View the vote results so far',
     buttonToHomepage: 'Back to Homepage',
+    buttonFestivalLink: 'Go to the festival site',
     buttonVote: 'Vote',
     errorVoteFailure: 'Your vote was not accepted .. did you already vote?',
+    festivalLinkPrompt: "Haven't finished checking out the artworks yet?",
   },
   VoteSessionCreator: {
     bodyBoothAddress: 'Booth address:',


### PR DESCRIPTION
This uses the "online" setting for the festivals, since remote-voting and hotspot-voting are only meant to be used for "online" festivals, and the booth is meant to be used for in-person ones

To test:
1.Set up an online festival for voting, with a valid url
2. Go to the vote page and verify that there is a button linking to the festival url

Closes #194 