### PR TITLE
Integrate mailgun as a production mailer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,13 +47,13 @@ HOTSPOT_MAX_VOTES=
 BARCODE_URL="https://barcode.tec-it.com/barcode.ashx?data={barcode}&code=Code128&multiplebarcodes=false&translate-esc=false&unit=Fit&dpi=600&imagetype=jpg&rotation=0&color=%23000000&bgcolor=%23ffffff&codepage=&qunit=Mm&quiet=0"
 
 # Mail sending
-STACK_MAIL_PORT=25
-STACK_MAIL_HOST=localhost
-STACK_MAIL_USER=
-STACK_MAIL_PASSWORD=
-STACK_MAIL_SENDER=meesix@example.org
+STAKE_MAIL_PORT=25
+STAKE_MAIL_HOST=localhost
+STAKE_MAIL_USER=
+STAKE_MAIL_PASSWORD=
+STAKE_MAIL_SENDER=meesix@example.org
 # set to `none` or leave empty to disable TLS all together, set to `tls` to use
 # TLS when connection to the server (usually use this if connecting using port
 # 465) or set to `starttls` to use the STARTTLS extension if supported by the
 # server (usually use this if the port is set to port 587).
-STACK_MAIL_SECURITY=none
+STAKE_MAIL_SECURITY=none

--- a/src/server/services/mailer.js
+++ b/src/server/services/mailer.js
@@ -13,17 +13,17 @@ export const devTransporter = {
 };
 
 export const prodTransporter = {
-  port: process.env.STACK_MAIL_PORT || 25,
-  host: process.env.STACK_MAIL_HOST || 'localhost',
-  ...(process.env.STACK_MAIL_USER && process.env.STACK_MAIL_PASSWORD
+  port: process.env.STAKE_MAIL_PORT || 25,
+  host: process.env.STAKE_MAIL_HOST || 'localhost',
+  ...(process.env.STAKE_MAIL_USER && process.env.STAKE_MAIL_PASSWORD
     ? {
         auth: {
-          user: process.env.STACK_MAIL_USER,
-          pass: process.env.STACK_MAIL_PASSWORD,
+          user: process.env.STAKE_MAIL_USER,
+          pass: process.env.STAKE_MAIL_PASSWORD,
         },
       }
     : undefined),
-  ...(process.env.STACK_MAIL_SECURITY === 'tls'
+  ...(process.env.STAKE_MAIL_SECURITY === 'tls'
     ? {
         secure: true,
         tls: {
@@ -31,7 +31,7 @@ export const prodTransporter = {
         },
       }
     : undefined),
-  ...(process.env.STACK_MAIL_SECURITY === 'starttls'
+  ...(process.env.STAKE_MAIL_SECURITY === 'starttls'
     ? {
         secure: false,
         requireTLS: true,
@@ -42,7 +42,7 @@ export const prodTransporter = {
     : undefined),
 };
 
-export const sender = process.env.STACK_MAIL_SENDER || 'meesix@example.org';
+export const sender = process.env.STAKE_MAIL_SENDER || 'meesix@example.org';
 
 export default (transport, from = sender) => {
   const transporter = nodemailer.createTransport(transport);
@@ -58,18 +58,15 @@ export default (transport, from = sender) => {
       throw new Error('Recipient or subject not set.');
     }
 
-    const text = views[template](data);
+    const html = views[template](data);
     const msg = await transporter.sendMail({
-      text,
+      html,
       to,
       subject,
       from,
     });
 
-    if (isDev) {
-      logger.info(msg.envelope);
-      logger.info(msg.message.toString());
-    }
+    if (isDev) logger.info(msg.message.toString());
   };
 
   return send;


### PR DESCRIPTION
To use mailgun actually only requires the correct SMTP settings and set
them in the `.env`. I have tested those and was abel to send several
mails to myself.

This PR makes the following modifications:

- rename the `.env` mail setting to start with `STAKE`.
- send emails as HTML emails.

closes #165