### PR TITLE
Add festival location name

### DIFF
--- a/src/client/components/FormFestivals.js
+++ b/src/client/components/FormFestivals.js
@@ -28,6 +28,7 @@ const FormFestivals = ({ hasQuestion, editing }) => {
     title: Joi.string().max(128).required(),
     url: Joi.string().uri().allow(''),
     thankyouUrl: Joi.string().uri().allow(''),
+    locationName: Joi.string().allow(''),
     question: {
       title: Joi.string().max(128).required(),
       type: Joi.valid('festival').required(),
@@ -48,6 +49,13 @@ const FormFestivals = ({ hasQuestion, editing }) => {
         name="subtitle"
         type="text"
         validate={schema.subtitle}
+      />
+
+      <InputField
+        label={translate('FormFestivals.fieldLocationName')}
+        name="locationName"
+        type="text"
+        validate={schema.locationName}
       />
 
       <InputField

--- a/src/client/views/AdminFestivalsEdit.js
+++ b/src/client/views/AdminFestivalsEdit.js
@@ -39,6 +39,7 @@ const AdminFestivalsEditForm = () => {
       'artworks',
       'description',
       'documents',
+      'locationName',
       'images',
       'online',
       'sticker',

--- a/src/client/views/AdminFestivalsNew.js
+++ b/src/client/views/AdminFestivalsNew.js
@@ -22,6 +22,7 @@ const AdminFestivalsNew = () => {
     fields: [
       'artworks',
       'description',
+      'locationName',
       'documents',
       'images',
       'online',

--- a/src/common/locales/index.js
+++ b/src/common/locales/index.js
@@ -101,6 +101,7 @@ const components = {
     fieldSticker: 'Sticker',
     fieldSubtitle: 'Subtitle',
     fieldTitle: 'Title:',
+    fieldLocationName: 'Location Name:',
     fieldQuestion: 'Question:',
     fieldArtworks: 'Artworks:',
     fieldUrl: 'Website:',

--- a/src/server/database/associations.js
+++ b/src/server/database/associations.js
@@ -44,6 +44,7 @@ export const festivalFields = [
   'url',
   'online',
   'thankyouUrl',
+  'locationName',
 ];
 export const invitationFields = [
   'boothSignature',

--- a/src/server/database/migrations/20210714054347-add-human-readable-location-name-to-festivals.js
+++ b/src/server/database/migrations/20210714054347-add-human-readable-location-name-to-festivals.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('festivals', 'locationName', {
+      type: Sequelize.STRING,
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.removeColumn('festivals', 'locationName');
+  },
+};

--- a/src/server/models/festival.js
+++ b/src/server/models/festival.js
@@ -53,6 +53,9 @@ const Festival = db.define('festival', {
   thankyouUrl: {
     type: DataTypes.STRING,
   },
+  locationName: {
+    type: DataTypes.STRING,
+  },
 });
 
 SequelizeSlugify.slugifyModel(Festival, {

--- a/src/server/validations/festivals.js
+++ b/src/server/validations/festivals.js
@@ -20,6 +20,7 @@ const defaultValidation = {
   title: Joi.string().max(128).required(),
   url: Joi.string().uri().allow(''),
   thankyouUrl: Joi.string().uri().allow(''),
+  locationName: Joi.string().allow(''),
 };
 
 const createValidation = {


### PR DESCRIPTION
The festival location name is an optional string field on the `Festival` model. This PR adds support for admins to set it on the admin interface and to store it in the database.

closes #229 