### PR TITLE
Vote results component 235

### DIFF
--- a/src/client/components/FestivalVoteResult.js
+++ b/src/client/components/FestivalVoteResult.js
@@ -1,0 +1,171 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+import Sticker from '~/client/components/Sticker';
+import { SNUGGLEPUNKS_COUNT } from '~/client/components/SVGDefinitions';
+import styles from '~/client/styles/variables';
+import { useSticker, useStickerImage } from '~/client/hooks/sticker';
+
+const SNUGGLEPUNK_SIZE = 10;
+
+const FestivalVoteResult = ({
+  rank,
+  total,
+  festivalSlug,
+  artistName,
+  artworkTitle,
+  artworkDesc,
+  artworkSlug,
+  images,
+  sticker,
+  votePower,
+}) => {
+  // Calculate SnugglePunk Happyness Factor === snuggleness!
+  const currentVotePower = Math.sqrt(total);
+  const snuggleness =
+    Math.round((currentVotePower / votePower) * (SNUGGLEPUNKS_COUNT - 1)) + 1;
+
+  // Get the sticker and color scheme
+  const stickerImagePath = useStickerImage(images);
+  const { scheme } = useSticker(sticker);
+
+  return (
+    <FestivalVoteResultStyle scheme={scheme}>
+      <FestivalVoteResultHeaderStyle>
+        <FestivalVoteResultRankStyle>{rank}</FestivalVoteResultRankStyle>
+
+        <SnuggleStyle>
+          <use xlinkHref={`#snugglepunk-${snuggleness}`} />
+        </SnuggleStyle>
+
+        <FestivalVoteResultVotesLayout>
+          <FestivalVoteResultVotesStyle>{total}</FestivalVoteResultVotesStyle>
+          Votes
+        </FestivalVoteResultVotesLayout>
+      </FestivalVoteResultHeaderStyle>
+
+      {stickerImagePath && (
+        <Sticker code={sticker} imagePath={stickerImagePath} />
+      )}
+
+      <FestivalVoteResultFooterStyle>
+        <FestivalVoteResultButtonStyle
+          href={`/festivals/${festivalSlug}/artworks/${artworkSlug}`}
+        >
+          <FestivalVoteResultHeadingStyle scheme={scheme}>
+            {artworkTitle}
+          </FestivalVoteResultHeadingStyle>
+        </FestivalVoteResultButtonStyle>
+
+        <FestivalVoteResultSubHeadingStyle scheme={scheme}>
+          {artistName} x {artworkDesc}
+        </FestivalVoteResultSubHeadingStyle>
+      </FestivalVoteResultFooterStyle>
+    </FestivalVoteResultStyle>
+  );
+};
+
+const FestivalVoteResultStyle = styled.div`
+  position: relative;
+
+  padding: 1em;
+`;
+
+const FestivalVoteResultHeaderStyle = styled.div`
+  display: flex;
+
+  justify-content: space-evenly;
+`;
+
+const FestivalVoteResultFooterStyle = styled.div`
+  display: flex;
+
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const FestivalVoteResultButtonStyle = styled.a`
+  font-family: ${styles.typography.familyHeading}, sans-serif;
+`;
+
+const FestivalVoteResultVotesLayout = styled.div`
+  display: flex;
+
+  align-items: center;
+  flex-direction: column;
+`;
+
+const FestivalVoteResultVotesStyle = styled.span`
+  display: flex;
+
+  font-size: 4em !important;
+  font-family: ${styles.typography.familyHeading}, sans-serif;
+
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const FestivalVoteResultRankStyle = styled.span`
+  font-size: 6em !important;
+  font-family: ${styles.typography.familyHeading}, sans-serif;
+`;
+
+const FestivalVoteResultHeadingStyle = styled.p`
+  margin-bottom: 1rem;
+
+  color: ${({ scheme }) => {
+    if (scheme) {
+      return styles.schemes[scheme].foreground;
+    }
+
+    return styles.colors.white;
+  }};
+
+  font-weight: ${styles.typography.weight};
+  font-size: 3em;
+  font-family: ${styles.typography.familyHeading}, sans-serif;
+
+  line-height: 0.9;
+`;
+
+const FestivalVoteResultSubHeadingStyle = styled.p`
+  color: ${({ scheme }) => {
+    if (scheme) {
+      return styles.schemes[scheme].foreground;
+    }
+
+    return styles.colors.white;
+  }};
+
+  font-weight: regular;
+  font-size: 1.5em !important;
+`;
+
+const SnuggleStyle = styled.svg`
+  position: relative;
+
+  width: ${SNUGGLEPUNK_SIZE}rem;
+  height: ${SNUGGLEPUNK_SIZE}rem;
+
+  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
+
+  transition: filter ease-in 0.2s;
+`;
+
+FestivalVoteResult.propTypes = {
+  artistName: PropTypes.string.isRequired,
+  artworkDesc: PropTypes.string.isRequired,
+  artworkSlug: PropTypes.string.isRequired,
+  artworkTitle: PropTypes.string.isRequired,
+  credit: PropTypes.number.isRequired,
+  festivalSlug: PropTypes.string.isRequired,
+  images: PropTypes.array,
+  rank: PropTypes.number.isRequired,
+  sticker: PropTypes.string.isRequired,
+  total: PropTypes.number.isRequired,
+  votePower: PropTypes.number.isRequired,
+};
+
+export default FestivalVoteResult;

--- a/src/client/components/VoteResult.js
+++ b/src/client/components/VoteResult.js
@@ -9,22 +9,21 @@ import { useSticker, useStickerImage } from '~/client/hooks/sticker';
 
 const SNUGGLEPUNK_SIZE = 10;
 
-const FestivalVoteResult = ({
+const VoteResult = ({
   rank,
   total,
-  festivalSlug,
-  artistName,
-  artworkTitle,
-  artworkDesc,
-  artworkSlug,
+  subtitle,
+  title,
   images,
   sticker,
-  votePower,
+  type,
+  credit,
 }) => {
   // Calculate SnugglePunk Happyness Factor === snuggleness!
-  const currentVotePower = Math.sqrt(total);
-  const snuggleness =
-    Math.round((currentVotePower / votePower) * (SNUGGLEPUNKS_COUNT - 1)) + 1;
+  const currentVotePower = Math.sqrt(credit);
+  const snuggleness = credit
+    ? Math.round((currentVotePower / total) * (SNUGGLEPUNKS_COUNT - 1))
+    : 1;
 
   // Get the sticker and color scheme
   const stickerImagePath = useStickerImage(images);
@@ -40,27 +39,25 @@ const FestivalVoteResult = ({
         </SnuggleStyle>
 
         <FestivalVoteResultVotesLayout>
-          <FestivalVoteResultVotesStyle>{total}</FestivalVoteResultVotesStyle>
+          <FestivalVoteResultVotesStyle>{credit}</FestivalVoteResultVotesStyle>
           Votes
         </FestivalVoteResultVotesLayout>
       </FestivalVoteResultHeaderStyle>
 
-      {stickerImagePath && (
+      {stickerImagePath && type === 'artwork' ? (
         <Sticker code={sticker} imagePath={stickerImagePath} />
-      )}
+      ) : null}
 
       <FestivalVoteResultFooterStyle>
-        <FestivalVoteResultButtonStyle
-          href={`/festivals/${festivalSlug}/artworks/${artworkSlug}`}
-        >
-          <FestivalVoteResultHeadingStyle scheme={scheme}>
-            {artworkTitle}
-          </FestivalVoteResultHeadingStyle>
-        </FestivalVoteResultButtonStyle>
+        <FestivalVoteResultHeadingStyle scheme={scheme}>
+          {title}
+        </FestivalVoteResultHeadingStyle>
 
-        <FestivalVoteResultSubHeadingStyle scheme={scheme}>
-          {artistName} x {artworkDesc}
-        </FestivalVoteResultSubHeadingStyle>
+        {type === 'artwork' && (
+          <FestivalVoteResultSubHeadingStyle scheme={scheme}>
+            {subtitle}
+          </FestivalVoteResultSubHeadingStyle>
+        )}
       </FestivalVoteResultFooterStyle>
     </FestivalVoteResultStyle>
   );
@@ -86,9 +83,9 @@ const FestivalVoteResultFooterStyle = styled.div`
   justify-content: center;
 `;
 
-const FestivalVoteResultButtonStyle = styled.a`
-  font-family: ${styles.typography.familyHeading}, sans-serif;
-`;
+// const FestivalVoteResultButtonStyle = styled.a`
+//   font-family: ${styles.typography.familyHeading}, sans-serif;
+// `;
 
 const FestivalVoteResultVotesLayout = styled.div`
   display: flex;
@@ -154,18 +151,15 @@ const SnuggleStyle = styled.svg`
   transition: filter ease-in 0.2s;
 `;
 
-FestivalVoteResult.propTypes = {
-  artistName: PropTypes.string.isRequired,
-  artworkDesc: PropTypes.string.isRequired,
-  artworkSlug: PropTypes.string.isRequired,
-  artworkTitle: PropTypes.string.isRequired,
+VoteResult.propTypes = {
   credit: PropTypes.number.isRequired,
-  festivalSlug: PropTypes.string.isRequired,
   images: PropTypes.array,
   rank: PropTypes.number.isRequired,
   sticker: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
   total: PropTypes.number.isRequired,
-  votePower: PropTypes.number.isRequired,
+  type: PropTypes.string.isRequired,
 };
 
-export default FestivalVoteResult;
+export default VoteResult;

--- a/src/client/views/ArtworksProfile.js
+++ b/src/client/views/ArtworksProfile.js
@@ -6,8 +6,8 @@ import BoxFramed from '~/client/components/BoxFramed';
 import ButtonGroup from '~/client/components/ButtonGroup';
 import ButtonIcon from '~/client/components/ButtonIcon';
 import ColorSection from '~/client/components/ColorSection';
+import VoteResult from '~/client/components/VoteResult';
 import Image from '~/client/components/Image';
-import Legend from '~/client/components/Legend';
 import Loading from '~/client/components/Loading';
 import PaperTicket from '~/client/components/PaperTicket';
 import Slider from '~/client/components/Slider';
@@ -196,26 +196,29 @@ const ArtworksProfile = () => {
 
                     <HorizontalSpacingStyle isLarge />
 
-                    {properties.map((property) => {
+                    {properties.map((property, idx) => {
+                      console.log(property) // eslint-disable-line
                       return (
-                        <ArtworksProfileProperty
-                          credit={property.voteTokens}
-                          key={property.id}
-                          scheme={scheme}
-                          title={property.title}
-                          total={maxVotePower}
-                        />
+                        <PaperTicket key={property.id}>
+                          <VoteResult
+                            credit={property.voteTokens}
+                            images={artwork.images}
+                            rank={idx + 1}
+                            sticker={artwork.sticker}
+                            subtitle={property.title}
+                            title={property.title}
+                            total={maxVotePower}
+                            type="property"
+                          />
+                        </PaperTicket>
                       );
                     })}
-
-                    <Legend
-                      scheme={scheme}
-                      title={translate('default.legendVotes')}
-                    />
 
                     <HorizontalSpacingStyle />
                   </Fragment>
                 )}
+
+                <HorizontalSpacingStyle isLarge />
 
                 <ButtonGroup>
                   <ButtonIcon

--- a/src/client/views/FestivalsProfile.js
+++ b/src/client/views/FestivalsProfile.js
@@ -1,18 +1,14 @@
-import PropTypes from 'prop-types';
 import React, { Fragment, useMemo } from 'react';
-import styled from 'styled-components';
 import { useParams, useHistory } from 'react-router-dom';
 
 import BoxFramed from '~/client/components/BoxFramed';
 import ButtonIcon from '~/client/components/ButtonIcon';
-import ButtonMore from '~/client/components/ButtonMore';
 import ColorSection from '~/client/components/ColorSection';
 import ContractsFestivalVotingPeriod from '~/client/components/ContractsFestivalVotingPeriod';
 import FestivalVoteResult from '~/client/components/FestivalVoteResult';
 import Loading from '~/client/components/Loading';
 import Paper from '~/client/components/Paper';
 import PaperTicket from '~/client/components/PaperTicket';
-import Slider from '~/client/components/Slider';
 import Sticker from '~/client/components/Sticker';
 import StickerHeading from '~/client/components/StickerHeading';
 import UnderlineLink from '~/client/components/UnderlineLink';
@@ -182,46 +178,6 @@ const FestivalsProfile = () => {
       </ColorSection>
     </View>
   );
-};
-
-const FestivalProfileArtwork = (props) => {
-  return (
-    <FestivalProfileArtworkStyle>
-      <FestivalProfileArtworkButtonStyle>
-        <ButtonMore
-          to={`/festivals/${props.festivalSlug}/artworks/${props.artworkSlug}`}
-        />
-      </FestivalProfileArtworkButtonStyle>
-
-      <HeadingSecondaryStyle>{props.title}</HeadingSecondaryStyle>
-      <HeadingSecondaryStyle>{props.artistName}</HeadingSecondaryStyle>
-
-      <Slider credit={props.credit} scheme={props.scheme} total={props.total} />
-
-      <HorizontalSpacingStyle />
-    </FestivalProfileArtworkStyle>
-  );
-};
-
-export const FestivalProfileArtworkStyle = styled.div`
-  position: relative;
-`;
-
-export const FestivalProfileArtworkButtonStyle = styled.div`
-  position: absolute;
-
-  top: 0;
-  right: 0;
-`;
-
-FestivalProfileArtwork.propTypes = {
-  artistName: PropTypes.string.isRequired,
-  artworkSlug: PropTypes.string.isRequired,
-  credit: PropTypes.number.isRequired,
-  festivalSlug: PropTypes.string.isRequired,
-  scheme: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  total: PropTypes.number.isRequired,
 };
 
 export default FestivalsProfile;

--- a/src/client/views/FestivalsProfile.js
+++ b/src/client/views/FestivalsProfile.js
@@ -8,7 +8,7 @@ import ButtonIcon from '~/client/components/ButtonIcon';
 import ButtonMore from '~/client/components/ButtonMore';
 import ColorSection from '~/client/components/ColorSection';
 import ContractsFestivalVotingPeriod from '~/client/components/ContractsFestivalVotingPeriod';
-import Legend from '~/client/components/Legend';
+import FestivalVoteResult from '~/client/components/FestivalVoteResult';
 import Loading from '~/client/components/Loading';
 import Paper from '~/client/components/Paper';
 import PaperTicket from '~/client/components/PaperTicket';
@@ -146,29 +146,31 @@ const FestivalsProfile = () => {
 
                     <HorizontalSpacingStyle isLarge />
 
-                    {artworks.map((artwork) => {
+                    {artworks.map((artwork, idx) => {
                       return (
-                        <FestivalProfileArtwork
-                          artistName={artwork.artist.name}
-                          artworkSlug={artwork.slug}
-                          credit={artwork.voteTokens}
-                          festivalSlug={festival.slug}
-                          key={artwork.id}
-                          scheme={scheme}
-                          title={artwork.title}
-                          total={maxVotePower}
-                        />
+                        <PaperTicket key={artwork.id}>
+                          <FestivalVoteResult
+                            artistName={artwork.artist.name}
+                            artworkDesc={artwork.description}
+                            artworkSlug={artwork.slug}
+                            artworkTitle={artwork.title}
+                            credit={artwork.voteTokens}
+                            festivalSlug={festival.slug}
+                            images={artwork.images}
+                            rank={idx + 1}
+                            sticker={artwork.sticker}
+                            total={maxVotePower}
+                            votePower={maxVotePower}
+                          />
+                        </PaperTicket>
                       );
                     })}
 
-                    <Legend
-                      scheme={scheme}
-                      title={translate('default.legendVotes')}
-                    />
-
-                    <HorizontalSpacingStyle />
+                    <HorizontalSpacingStyle isLarge />
                   </Fragment>
                 )}
+
+                <HorizontalSpacingStyle />
 
                 <ButtonIcon to={`/festivals/${festival.slug}/artworks`}>
                   {translate('FestivalsProfile.buttonShowAllArtworks')}

--- a/src/client/views/FestivalsProfile.js
+++ b/src/client/views/FestivalsProfile.js
@@ -5,7 +5,7 @@ import BoxFramed from '~/client/components/BoxFramed';
 import ButtonIcon from '~/client/components/ButtonIcon';
 import ColorSection from '~/client/components/ColorSection';
 import ContractsFestivalVotingPeriod from '~/client/components/ContractsFestivalVotingPeriod';
-import FestivalVoteResult from '~/client/components/FestivalVoteResult';
+import VoteResult from '~/client/components/VoteResult';
 import Loading from '~/client/components/Loading';
 import Paper from '~/client/components/Paper';
 import PaperTicket from '~/client/components/PaperTicket';
@@ -145,18 +145,15 @@ const FestivalsProfile = () => {
                     {artworks.map((artwork, idx) => {
                       return (
                         <PaperTicket key={artwork.id}>
-                          <FestivalVoteResult
-                            artistName={artwork.artist.name}
-                            artworkDesc={artwork.description}
-                            artworkSlug={artwork.slug}
-                            artworkTitle={artwork.title}
+                          <VoteResult
                             credit={artwork.voteTokens}
-                            festivalSlug={festival.slug}
                             images={artwork.images}
                             rank={idx + 1}
                             sticker={artwork.sticker}
+                            subtitle={artwork.artist.name}
+                            title={artwork.title}
                             total={maxVotePower}
-                            votePower={maxVotePower}
+                            type="artwork"
                           />
                         </PaperTicket>
                       );

--- a/src/server/controllers/votes.js
+++ b/src/server/controllers/votes.js
@@ -9,10 +9,12 @@ import {
   AnswerBelongsToArtwork,
   AnswerBelongsToProperty,
   ArtworkBelongsToArtist,
+  ArtworkHasManyImages,
   QuestionHasManyAnswers,
   VoteBelongsToManyVoteweights,
   artistFields,
   artworkFields,
+  imageFileFields,
   propertyFields,
   questionFields,
   voteFields,
@@ -35,11 +37,16 @@ const answerAssociation = {
   associations: [
     {
       association: AnswerBelongsToArtwork,
-      fields: [...artworkFields, 'artist'],
+      fields: [...artworkFields, 'artist', 'images'],
       associations: [
         {
           association: ArtworkBelongsToArtist,
           fields: [...artistFields],
+        },
+        {
+          association: ArtworkHasManyImages,
+          destroyCascade: false,
+          fields: [...imageFileFields],
         },
       ],
     },
@@ -77,7 +84,7 @@ const optionsResults = {
       include: [
         {
           association: AnswerBelongsToArtwork,
-          include: ArtworkBelongsToArtist,
+          include: [ArtworkBelongsToArtist, ArtworkHasManyImages],
         },
         AnswerBelongsToProperty,
       ],


### PR DESCRIPTION
This PR adds a dedicated component to display artwork vote results. It supersedes the current way of displaying the votes using the voting slider. The design is based on the screenshot in #235. Here a few notes:

- I didn't color the background of the `PaperTicket` of each vote result. I thought it looked weird since it colored the paper ticket divider as well and overlapped with the following `PaperTicket`. Instead I use the primary artwork color to tint the sticker and the artwork descriptions on the bottom.
- From looking at the design screenshot, I wasn't sure which fields all went into the bottom part of the vote result. I settled on printing the artwork title, the artist name and the artwork description.

Here is an example how it looks at the momen.

![Screenshot 2021-07-28 at 16-09-07 Culture Stake](https://user-images.githubusercontent.com/29301569/127357939-ca8c1d45-350a-4857-b3b6-7273b4f5af34.png)

closes #235 